### PR TITLE
Implement "OR" and "AND" rules kinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,17 @@ Three kinds of rules are available:
 - Basic Rule, through which you specify **top-level** `users` and `teams` for
   reaching `min_approvals`
 
-- AND Rule, through which you specify sub-conditions of `users` and `teams`,
-  each with its own `min_approvals`, and **all** of them (logical `AND`) should
+- AND Rule, through which you specify subcondition of `users` and `teams`, each
+  with its own `min_approvals`, and **all** of them (logical `AND`) should
   reach their respective `min_approvals`
 
-- OR Rule, through which you specify sub-conditions of `users` and `teams`,
-  each with its own `min_approvals`, and **any** of them (logical `OR`) should
-  reach their respective `min_approvals`
+- OR Rule, through which you specify subcondition of `users` and `teams`, each
+  with its own `min_approvals`, and **any** of them (logical `OR`) should reach
+  their respective `min_approvals`
 
 It's not possible to mix fields from different rules kinds. For instance, it's
 invalid to specify a **top-level** `min_approvals` for AND or OR rules: the
-criteria should be put in the sub-conditions instead.
+criteria should be put in the subcondition instead.
 
 #### Basic Rule syntax <a name="basic-rule-syntax"></a>
 
@@ -90,7 +90,7 @@ rules:
 
 #### AND Rule syntax <a name="and-rule-syntax"></a>
 
-AND Rules will only match if **all** the subconditions listed in `all` are
+AND Rules will only match if **all** subconditions listed in `all` are
 fulfilled.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ rules:
 #### And Rule syntax <a name="and-rule-syntax"></a>
 
 And Rules will only match if **all** the subconditions listed in `all` are
-fulfilled. Note that we are not specifying top-level fields from
-[basic rules](#basic-rule-syntax).
+fulfilled.
 
 ```yaml
 rules:
@@ -115,8 +114,6 @@ field.
 #### Or Rule syntax <a name="or-rule-syntax"></a>
 
 Or Rules will match if **any** subconditions listed in `any` are fulfilled.
-Note that we are not specifying top-level fields from
-[basic rules](#basic-rule-syntax).
 
 ```yaml
 rules:

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This is a GitHub Action created for complex pull request approval scenarios whic
   - [Action configuration](#action-configuration)
   - [Rules syntax](#rules-syntax)
     - [Basic Rule syntax](#basic-rule-syntax)
-    - [And Rule syntax](#and-rule-syntax)
-    - [Or Rule syntax](#or-rule-syntax)
+    - [AND Rule syntax](#and-rule-syntax)
+    - [OR Rule syntax](#or-rule-syntax)
   - [Workflow configuration](#workflow-configuration)
   - [GitHub repository configuration](#github-repository-configuration)
 - [Development](#development)
@@ -48,19 +48,20 @@ If you don't want to use a configuration file, set `config-file` to an empty val
 
 Three kinds of rules are available:
 
-- **Basic** Rule, through which you specify **top-level** `users` and `teams`
-  for reaching `min_approvals`
+- Basic Rule, through which you specify **top-level** `users` and `teams` for
+  reaching `min_approvals`
 
-- **All** Rule, through which you specify sub-conditions of `users` and
-  `teams`, each with its own `min_approvals`, and **all** of them (logical
-  `AND`) should reach their respective `min_approvals`
+- AND Rule, through which you specify sub-conditions of `users` and `teams`,
+  each with its own `min_approvals`, and **all** of them (logical `AND`) should
+  reach their respective `min_approvals`
 
-- **Or** Rule, through which you specify sub-conditions of `users` and `teams`,
+- OR Rule, through which you specify sub-conditions of `users` and `teams`,
   each with its own `min_approvals`, and **any** of them (logical `OR`) should
   reach their respective `min_approvals`
 
-Note that each rule kind is treated separately. For instance, it's not possible
-to specify a top-level `min_approvals` for **All** or **Or** rules.
+It's not possible to mix fields from different rules kinds. For instance, it's
+invalid to specify a **top-level** `min_approvals` for AND or OR rules: the
+criteria should be put in the sub-conditions instead.
 
 #### Basic Rule syntax <a name="basic-rule-syntax"></a>
 
@@ -87,9 +88,9 @@ rules:
       - team2
 ```
 
-#### And Rule syntax <a name="and-rule-syntax"></a>
+#### AND Rule syntax <a name="and-rule-syntax"></a>
 
-And Rules will only match if **all** the subconditions listed in `all` are
+AND Rules will only match if **all** the subconditions listed in `all` are
 fulfilled.
 
 ```yaml
@@ -111,9 +112,9 @@ rules:
 Visit [Basic Rule syntax](#basic-rule-syntax) for the full explanation of each
 field.
 
-#### Or Rule syntax <a name="or-rule-syntax"></a>
+#### OR Rule syntax <a name="or-rule-syntax"></a>
 
-Or Rules will match if **any** subconditions listed in `any` are fulfilled.
+OR Rules will match if **any** subconditions listed in `any` are fulfilled.
 
 ```yaml
 rules:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ This is a GitHub Action created for complex pull request approval scenarios whic
   - [High level flow chart](#high-level-flow-chart)
 - [Configuration](#configuration)
   - [Action configuration](#action-configuration)
-    - [Rules syntax](#rules-syntax)
+  - [Rules syntax](#rules-syntax)
+    - [Basic Rule syntax](#basic-rule-syntax)
+    - [And Rule syntax](#and-rule-syntax)
+    - [Or Rule syntax](#or-rule-syntax)
   - [Workflow configuration](#workflow-configuration)
   - [GitHub repository configuration](#github-repository-configuration)
 - [Development](#development)
@@ -41,14 +44,33 @@ Configuration is done through a `pr-custom-review-config.yml` file placed in the
 
 If you don't want to use a configuration file, set `config-file` to an empty value as demonstrated in [Workflow configuration](#workflow-configuration).
 
-#### Rules syntax <a name="rules-syntax"></a>
+### Rules syntax <a name="rules-syntax"></a>
+
+Three kinds of rules are available:
+
+- **Basic** Rule, through which you specify **top-level** `users` and `teams`
+  for reaching `min_approvals`
+
+- **All** Rule, through which you specify sub-conditions of `users` and
+  `teams`, each with its own `min_approvals`, and **all** of them (logical
+  `AND`) should reach their respective `min_approvals`
+
+- **Or** Rule, through which you specify sub-conditions of `users` and `teams`,
+  each with its own `min_approvals`, and **any** of them (logical `OR`) should
+  reach their respective `min_approvals`
+
+Note that each rule kind is treated separately. For instance, it's not possible
+to specify a top-level `min_approvals` for **All** or **Or** rules.
+
+#### Basic Rule syntax <a name="basic-rule-syntax"></a>
 
 ```yaml
 rules:
-  - name: CHECK NAME     # Used for the status check description. Keep it short
+  - name: Rule name      # Used for the status check description. Keep it short
                          # as GitHub imposes a limit of 140 chars.
     condition: .*        # Javascript Regular Expression used to match the rule.
-                         # Do not include the slashes at the beginning or end.
+                         # Do not include RegExp delimiters (`/`) at the
+                         # beginning or end.
     check_type: diff     # Either "diff" or "changed_files".
     min_approvals: 2     # Minimum required approvals.
     users:
@@ -64,6 +86,56 @@ rules:
       - team1
       - team2
 ```
+
+#### And Rule syntax <a name="and-rule-syntax"></a>
+
+And Rules will only match if **all** the subconditions listed in `all` are
+fulfilled. Note that we are not specifying top-level fields from
+[basic rules](#basic-rule-syntax).
+
+```yaml
+rules:
+  - name: Rule name
+    condition: .*
+    check_type: diff
+    all:
+      - min_approvals: 1
+        users:
+          - user1
+      - min_approvals: 1
+        users:
+          - user2
+        teams:
+          - team1
+```
+
+Visit [Basic Rule syntax](#basic-rule-syntax) for the full explanation of each
+field.
+
+#### Or Rule syntax <a name="or-rule-syntax"></a>
+
+Or Rules will match if **any** subconditions listed in `any` are fulfilled.
+Note that we are not specifying top-level fields from
+[basic rules](#basic-rule-syntax).
+
+```yaml
+rules:
+  - name: Rule name
+    condition: .*
+    check_type: diff
+    any:
+      - min_approvals: 1
+        users:
+          - user1
+      - min_approvals: 1
+        users:
+          - user2
+        teams:
+          - team1
+```
+
+Visit [Basic Rule syntax](#basic-rule-syntax) for the full explanation of each
+field.
 
 ### Workflow configuration <a name="workflow-configuration"></a>
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,15 +9,6 @@ import {
 export const commitStateSuccess: CommitState = "success"
 export const commitStateFailure: CommitState = "failure"
 
-// Fields used for detecting the different kinds of rules
-export const simpleRuleUniqueFields: Array<keyof BasicRule> = [
-  "min_approvals",
-  "teams",
-  "users",
-]
-export const andRuleUniqueFields: Array<keyof AndRule> = ["all"]
-export const orRuleUniqueFields: Array<keyof OrRule> = ["any"]
-
 export const rulesConfigurations: RulesConfigurations = {
   basic: {
     kind: "BasicRule",
@@ -35,3 +26,13 @@ export const rulesConfigurations: RulesConfigurations = {
     invalidFields: ["min_approvals", "teams", "users", "all"],
   },
 }
+
+// Fields used for detecting the different kinds of rules
+export const simpleRuleUniqueFields: RulesConfigurations["basic"]["uniqueFields"] =
+  ["min_approvals", "teams", "users"]
+export const andRuleUniqueFields: RulesConfigurations["and"]["uniqueFields"] = [
+  "all",
+]
+export const orRuleUniqueFields: RulesConfigurations["or"]["uniqueFields"] = [
+  "any",
+]

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,13 @@
-import { CommitState } from "./types"
+import { AndRule, BasicRule, CommitState, OrRule } from "./types"
 
 export const commitStateSuccess: CommitState = "success"
 export const commitStateFailure: CommitState = "failure"
+
+// Fields used for detecting the different kinds of rules
+export const simpleRuleUniqueFields: Array<keyof BasicRule> = [
+  "min_approvals",
+  "teams",
+  "users",
+]
+export const andRuleUniqueFields: Array<keyof AndRule> = ["all"]
+export const orRuleUniqueFields: Array<keyof OrRule> = ["any"]

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,10 @@
-import { AndRule, BasicRule, CommitState, OrRule } from "./types"
+import {
+  AndRule,
+  BasicRule,
+  CommitState,
+  OrRule,
+  RulesConfigurations,
+} from "./types"
 
 export const commitStateSuccess: CommitState = "success"
 export const commitStateFailure: CommitState = "failure"
@@ -11,3 +17,21 @@ export const simpleRuleUniqueFields: Array<keyof BasicRule> = [
 ]
 export const andRuleUniqueFields: Array<keyof AndRule> = ["all"]
 export const orRuleUniqueFields: Array<keyof OrRule> = ["any"]
+
+export const rulesConfigurations: RulesConfigurations = {
+  basic: {
+    kind: "BasicRule",
+    uniqueFields: ["min_approvals", "teams", "users"],
+    invalidFields: ["any", "all"],
+  },
+  and: {
+    kind: "AndRule",
+    uniqueFields: ["all"],
+    invalidFields: ["min_approvals", "teams", "users", "any"],
+  },
+  or: {
+    kind: "OrRule",
+    uniqueFields: ["any"],
+    invalidFields: ["min_approvals", "teams", "users", "all"],
+  },
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,4 @@
-import {
-  AndRule,
-  BasicRule,
-  CommitState,
-  OrRule,
-  RulesConfigurations,
-} from "./types"
+import { CommitState, RulesConfigurations } from "./types"
 
 export const commitStateSuccess: CommitState = "success"
 export const commitStateFailure: CommitState = "failure"
@@ -26,13 +20,3 @@ export const rulesConfigurations: RulesConfigurations = {
     invalidFields: ["min_approvals", "teams", "users", "all"],
   },
 }
-
-// Fields used for detecting the different kinds of rules
-export const simpleRuleUniqueFields: RulesConfigurations["basic"]["uniqueFields"] =
-  ["min_approvals", "teams", "users"]
-export const andRuleUniqueFields: RulesConfigurations["and"]["uniqueFields"] = [
-  "all",
-]
-export const orRuleUniqueFields: RulesConfigurations["or"]["uniqueFields"] = [
-  "any",
-]

--- a/src/core.ts
+++ b/src/core.ts
@@ -421,30 +421,26 @@ export const runChecks = async function (
             }
           }
         } else if (outcome instanceof RuleFailure) {
-          if (outcome instanceof RuleFailure) {
-            pendingProblems.push(outcome.problem)
-            for (const [username, userInfo] of outcome.usersToAskForReview) {
-              const prevUser = pendingUsersToAskForReview.get(username)
-              if (
-                // Avoid registering the same user twice
-                prevUser === undefined ||
-                // If the team is null, this user was not asked as part of a
-                // team, but individually. They should always be registered with
-                // "team: null" that case to be sure the review will be
-                // requested individually, even if they were previously
-                // registered as part of a team.
-                userInfo.team === null
-              ) {
-                pendingUsersToAskForReview.set(username, {
-                  team: userInfo.team,
-                })
-              }
+          pendingProblems.push(outcome.problem)
+          for (const [username, userInfo] of outcome.usersToAskForReview) {
+            const prevUser = pendingUsersToAskForReview.get(username)
+            if (
+              // Avoid registering the same user twice
+              prevUser === undefined ||
+              // If the team is null, this user was not asked as part of a
+              // team, but individually. They should always be registered with
+              // "team: null" that case to be sure the review will be
+              // requested individually, even if they were previously
+              // registered as part of a team.
+              userInfo.team === null
+            ) {
+              pendingUsersToAskForReview.set(username, { team: userInfo.team })
             }
-          } else {
-            logger.failure("Unable to process unexpected rule outcome")
-            logger.log(outcome)
-            return commitStateFailure
           }
+        } else {
+          logger.failure("Unable to process unexpected rule outcome")
+          logger.log(outcome)
+          return commitStateFailure
         }
       }
       for (const pendingProblem of pendingProblems) {

--- a/src/core.ts
+++ b/src/core.ts
@@ -267,8 +267,12 @@ export const runChecks = async function (
         continue
       }
 
-      if ("min_approvals" in rule) {
-        // BasicRule
+      if (/* BasicRule */ "min_approvals" in rule) {
+        if (typeof rule.min_approvals !== "number") {
+          logger.failure(`Rule "${rule.name}" has invalid min_approvals`)
+          logger.log(rule)
+          return commitStateFailure
+        }
 
         const users = await combineUsers(
           pr,
@@ -284,14 +288,14 @@ export const runChecks = async function (
           kind: "BasicRule",
           id: ++nextMatchedRuleId,
         })
-      } else if ("all" in rule) {
+      } else if (/* AndRule */ "all" in rule) {
         await processRulesConditions(
           ++nextMatchedRuleId,
           rule.name,
           rule.all,
           "AndRule",
         )
-      } else if ("any" in rule) {
+      } else if (/* OrRule */ "any" in rule) {
         await processRulesConditions(
           ++nextMatchedRuleId,
           rule.name,

--- a/src/core.ts
+++ b/src/core.ts
@@ -193,8 +193,6 @@ export const runChecks = async function (
     }
 
     for (const rule of config.rules) {
-      const id = ++nextMatchedRuleId
-
       const condition: RegExp = new RegExp(rule.condition, "gm")
 
       // Validate that rules which are matched to a "kind" do not have fields of other "kinds"
@@ -285,12 +283,22 @@ export const runChecks = async function (
           min_approvals: rule.min_approvals,
           users,
           kind: "BasicRule",
-          id,
+          id: ++nextMatchedRuleId,
         })
       } else if ("all" in rule) {
-        await processRulesConditions(id, rule.name, rule.all, "AndRule")
+        await processRulesConditions(
+          ++nextMatchedRuleId,
+          rule.name,
+          rule.all,
+          "AndRule",
+        )
       } else if ("any" in rule) {
-        await processRulesConditions(id, rule.name, rule.any, "OrRule")
+        await processRulesConditions(
+          ++nextMatchedRuleId,
+          rule.name,
+          rule.any,
+          "OrRule",
+        )
       } else {
         const unmatchedRule = rule as BaseRule
         throw new Error(

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,8 +1,24 @@
 import YAML from "yaml"
 
-import { commitStateFailure, commitStateSuccess } from "./constants"
+import {
+  andRuleUniqueFields,
+  commitStateFailure,
+  commitStateSuccess,
+  orRuleUniqueFields,
+  simpleRuleUniqueFields,
+} from "./constants"
 import { LoggerInterface } from "./logger"
-import { Octokit, PR, RuleUserInfo } from "./types"
+import {
+  BaseRule,
+  MatchedRule,
+  Octokit,
+  PR,
+  RuleCriteria,
+  RuleFailure,
+  RuleKind,
+  RuleSuccess,
+  RuleUserInfo,
+} from "./types"
 import { configurationSchema } from "./validation"
 
 const combineUsers = async function (
@@ -78,19 +94,22 @@ export const runChecks = async function (
   }
   const { data: diff } = diffResponse
 
-  type MatchedRule = {
-    name: string
-    min_approvals: number
-    users: Map<string, RuleUserInfo>
-  }
   const matchedRules: MatchedRule[] = []
+  let nextMatchedRuleId = -1
 
   // Built in condition to search files with changes to locked lines
   const lockExpression = /🔒[^\n]*\n[+|-]|(^|\n)[+|-][^\n]*🔒/
   if (lockExpression.test(diff)) {
     logger.log("Diff has changes to 🔒 lines or lines following 🔒")
     const users = await combineUsers(pr, octokit, [], [locksReviewTeam])
-    matchedRules.push({ name: "LOCKS TOUCHED", min_approvals: 2, users })
+    const name = "LOCKS TOUCHED"
+    matchedRules.push({
+      name: name,
+      min_approvals: 2,
+      kind: "BasicRule",
+      users,
+      id: ++nextMatchedRuleId,
+    })
   }
 
   if (configFilePath === null || configFilePath.length === 0) {
@@ -151,8 +170,68 @@ export const runChecks = async function (
     // The actual files will be loaded later in case some rule needs it
     let changedFiles: Set<string> | undefined = undefined
 
+    const processRulesConditions = async function (
+      id: MatchedRule["id"],
+      ruleName: string,
+      ruleCriterias: RuleCriteria[],
+      kind: RuleKind,
+    ) {
+      let conditionIndex = -1
+      for (const condition of ruleCriterias) {
+        const users = await combineUsers(
+          pr,
+          octokit,
+          condition.users ?? [],
+          condition.teams ?? [],
+        )
+        matchedRules.push({
+          name: `${ruleName}[${++conditionIndex}]`,
+          min_approvals: condition.min_approvals,
+          users,
+          kind,
+          id,
+        })
+      }
+    }
+
     for (const rule of config.rules) {
+      const id = ++nextMatchedRuleId
+
       const condition: RegExp = new RegExp(rule.condition, "gm")
+
+      // Validate that rules which are matched to a "kind" do not have fields of other "kinds"
+      for (const [kind, fields, invalidFieldsGroup] of [
+        [
+          "BasicRule",
+          simpleRuleUniqueFields,
+          [andRuleUniqueFields, orRuleUniqueFields],
+        ],
+        [
+          "AndRule",
+          andRuleUniqueFields,
+          [simpleRuleUniqueFields, orRuleUniqueFields],
+        ],
+        [
+          "OrRule",
+          orRuleUniqueFields,
+          [simpleRuleUniqueFields, andRuleUniqueFields],
+        ],
+      ]) {
+        for (const field of fields) {
+          if (typeof field === "string" && field in rule) {
+            for (const invalidFields of invalidFieldsGroup) {
+              for (const invalidField of invalidFields) {
+                if (invalidField in rule) {
+                  logger.failure(
+                    `Rule "${rule.name}" was expected to be of kind "${kind}" because it had the field "${field}", but it also has the field "${invalidField}", which belongs to another kind. Mixing fields from different kinds of rules is not allowed.`,
+                  )
+                  return commitStateFailure
+                }
+              }
+            }
+          }
+        }
+      }
 
       let matched = false
       switch (rule.check_type) {
@@ -209,18 +288,33 @@ export const runChecks = async function (
         continue
       }
 
-      const users = await combineUsers(
-        pr,
-        octokit,
-        rule.users ?? [],
-        rule.teams ?? [],
-      )
+      if ("min_approvals" in rule) {
+        // BasicRule
 
-      matchedRules.push({
-        name: rule.name,
-        min_approvals: rule.min_approvals,
-        users,
-      })
+        const users = await combineUsers(
+          pr,
+          octokit,
+          rule.users ?? [],
+          rule.teams ?? [],
+        )
+
+        matchedRules.push({
+          name: rule.name,
+          min_approvals: rule.min_approvals,
+          users,
+          kind: "BasicRule",
+          id,
+        })
+      } else if ("all" in rule) {
+        await processRulesConditions(id, rule.name, rule.all, "AndRule")
+      } else if ("any" in rule) {
+        await processRulesConditions(id, rule.name, rule.any, "OrRule")
+      } else {
+        const unmatchedRule = rule as BaseRule
+        throw new Error(
+          `Rule "${unmatchedRule.name}" could not be matched to any known kind`,
+        )
+      }
     }
   }
 
@@ -262,18 +356,26 @@ export const runChecks = async function (
     }
     logger.log("latestReviews", latestReviews.values())
 
-    const problems: string[] = []
+    const rulesOutcomes: Map<
+      MatchedRule["id"],
+      Array<RuleSuccess | RuleFailure>
+    > = new Map()
 
-    const usersToAskForReview: Map<string, RuleUserInfo> = new Map()
     let highestMinApprovalsRule: MatchedRule | null = null
     for (const rule of matchedRules) {
+      const outcomes = rulesOutcomes.get(rule.id) ?? []
+
       if (rule.users.size !== 0) {
         const approvedBy: Set<string> = new Set()
+
         for (const review of latestReviews.values()) {
           if (rule.users.has(review.user) && review.isApproval) {
             approvedBy.add(review.user)
           }
         }
+
+        const usersToAskForReview: Map<string, RuleUserInfo> = new Map()
+
         if (approvedBy.size < rule.min_approvals) {
           const missingApprovals: {
             username: string
@@ -297,25 +399,89 @@ export const runChecks = async function (
               }
             }
           }
-          problems.push(
-            `Rule "${rule.name}" needs at least ${
-              rule.min_approvals
-            } approvals, but ${
-              approvedBy.size
-            } were matched. The following users have not approved yet: ${missingApprovals
-              .map(function (user) {
-                return `${
-                  user.username
-                }${user.team ? ` (team: ${user.team})` : ""}`
-              })
-              .join(", ")}.`,
-          )
+          const problem = `Rule "${rule.name}" needs at least ${
+            rule.min_approvals
+          } approvals, but ${
+            approvedBy.size
+          } were matched. The following users have not approved yet: ${missingApprovals
+            .map(function (user) {
+              return `${
+                user.username
+              }${user.team ? ` (team: ${user.team})` : ""}`
+            })
+            .join(", ")}.`
+          outcomes.push(new RuleFailure(rule, problem, usersToAskForReview))
+        } else {
+          outcomes.push(new RuleSuccess(rule))
         }
+
+        rulesOutcomes.set(rule.id, outcomes)
       } else if (
         highestMinApprovalsRule === null ||
         highestMinApprovalsRule.min_approvals < rule.min_approvals
       ) {
         highestMinApprovalsRule = rule
+      }
+    }
+
+    const problems: string[] = []
+    const usersToAskForReview: Map<string, RuleUserInfo> = new Map()
+
+    toNextOutcomes: for (const outcomes of rulesOutcomes.values()) {
+      const pendingUsersToAskForReview: Map<string, RuleUserInfo> = new Map()
+      const pendingProblems: string[] = []
+      for (const outcome of outcomes) {
+        if (outcome instanceof RuleSuccess) {
+          switch (outcome.rule.kind) {
+            case "BasicRule":
+            case "OrRule": {
+              continue toNextOutcomes
+            }
+          }
+        } else if (outcome instanceof RuleFailure) {
+          if (outcome instanceof RuleFailure) {
+            pendingProblems.push(outcome.problem)
+            for (const [username, userInfo] of outcome.usersToAskForReview) {
+              const prevUser = pendingUsersToAskForReview.get(username)
+              if (
+                // Avoid registering the same user twice
+                prevUser === undefined ||
+                // If the team is null, this user was not asked as part of a
+                // team, but individually. They should always be registered with
+                // "team: null" that case to be sure the review will be
+                // requested individually, even if they were previously
+                // registered as part of a team.
+                userInfo.team === null
+              ) {
+                pendingUsersToAskForReview.set(username, {
+                  team: userInfo.team,
+                })
+              }
+            }
+          } else {
+            logger.failure("Unable to process unexpected rule outcome")
+            logger.log(outcome)
+            return commitStateFailure
+          }
+        }
+      }
+      for (const pendingProblem of pendingProblems) {
+        problems.push(pendingProblem)
+      }
+      for (const [username, userInfo] of pendingUsersToAskForReview) {
+        const prevUser = usersToAskForReview.get(username)
+        if (
+          // Avoid registering the same user twice
+          prevUser === undefined ||
+          // If the team is null, this user was not asked as part of a
+          // team, but individually. They should always be registered with
+          // "team: null" that case to be sure the review will be
+          // requested individually, even if they were previously
+          // registered as part of a team.
+          userInfo.team === null
+        ) {
+          usersToAskForReview.set(username, { team: userInfo.team })
+        }
       }
     }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -162,12 +162,6 @@ export const runChecks = async function (
     }
     const config = validationResult.value
 
-    // Unlike diff, which is always requested for checking the locks built-in
-    // rule, we do not need to load the changed files upfront, only if there's
-    // some changed_files rule
-    // The actual files will be loaded later in case some rule needs it
-    let changedFiles: Set<string> | undefined = undefined
-
     const processRulesConditions = async function (
       id: MatchedRule["id"],
       ruleName: string,
@@ -192,6 +186,11 @@ export const runChecks = async function (
       }
     }
 
+    // Unlike diff, which is always requested for checking the locks built-in
+    // rule, we do not need to load the changed files upfront, only if there's
+    // some changed_files rule
+    // The actual files will be loaded later in case some rule needs it
+    let changedFiles: Set<string> | undefined = undefined
     for (const rule of config.rules) {
       const condition: RegExp = new RegExp(rule.condition, "gm")
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,17 +34,17 @@ export type BaseRule = {
 
 export type RuleCriteria = {
   min_approvals: number
-  users: Array<string> | undefined | null
-  teams: Array<string> | undefined | null
+  users?: Array<string> | null
+  teams?: Array<string> | null
 }
 
-type BasicRule = BaseRule & RuleCriteria
+export type BasicRule = BaseRule & RuleCriteria
 
-type OrRule = BaseRule & {
+export type OrRule = BaseRule & {
   any: RuleCriteria[]
 }
 
-type AndRule = BaseRule & {
+export type AndRule = BaseRule & {
   all: RuleCriteria[]
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,31 @@ export type AndRule = BaseRule & {
 
 export type RuleKind = "BasicRule" | "OrRule" | "AndRule"
 export type Rule = BasicRule | OrRule | AndRule
+export type RuleConfiguration<Kind extends RuleKind> = Kind extends "BasicRule"
+  ? {
+      kind: Kind
+      uniqueFields: ["min_approvals", "teams", "users"]
+      invalidFields: ["any", "all"]
+    }
+  : Kind extends "AndRule"
+  ? {
+      kind: Kind
+      uniqueFields: ["all"]
+      invalidFields: ["min_approvals", "teams", "users", "any"]
+    }
+  : Kind extends "OrRule"
+  ? {
+      kind: Kind
+      uniqueFields: ["any"]
+      invalidFields: ["min_approvals", "teams", "users", "all"]
+    }
+  : never
+
+export type RulesConfigurations = {
+  basic: RuleConfiguration<"BasicRule">
+  and: RuleConfiguration<"AndRule">
+  or: RuleConfiguration<"OrRule">
+}
 
 export type Configuration = {
   rules: Rule[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export type AndRule = BaseRule & {
 
 export type RuleKind = "BasicRule" | "OrRule" | "AndRule"
 export type Rule = BasicRule | OrRule | AndRule
+
 type RuleConfiguration<Kind extends RuleKind> = Kind extends "BasicRule"
   ? {
       kind: Kind
@@ -69,7 +70,6 @@ type RuleConfiguration<Kind extends RuleKind> = Kind extends "BasicRule"
       invalidFields: ["min_approvals", "teams", "users", "all"]
     }
   : never
-
 export type RulesConfigurations = {
   basic: RuleConfiguration<"BasicRule">
   and: RuleConfiguration<"AndRule">
@@ -86,7 +86,7 @@ export type MatchedRule = {
   name: string
   min_approvals: number
   users: Map<string, RuleUserInfo>
-  kind: "BasicRule" | "AndRule" | "OrRule"
+  kind: RuleKind
   id: number
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,19 +38,19 @@ export type RuleCriteria = {
   teams: Array<string> | undefined | null
 }
 
-export type BasicRule = BaseRule & RuleCriteria
+type BasicRule = BaseRule & RuleCriteria
 
-export type OrRule = BaseRule & {
+type OrRule = BaseRule & {
   any: RuleCriteria[]
 }
 
-export type AndRule = BaseRule & {
+type AndRule = BaseRule & {
   all: RuleCriteria[]
 }
 
 export type RuleKind = "BasicRule" | "OrRule" | "AndRule"
 export type Rule = BasicRule | OrRule | AndRule
-export type RuleConfiguration<Kind extends RuleKind> = Kind extends "BasicRule"
+type RuleConfiguration<Kind extends RuleKind> = Kind extends "BasicRule"
   ? {
       kind: Kind
       uniqueFields: ["min_approvals", "teams", "users"]

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,17 +26,52 @@ export type PR = {
   html_url: string
 }
 
-export type Rule = {
+export type BaseRule = {
   name: string
   condition: string
   check_type: "diff" | "changed_files"
+}
+
+export type RuleCriteria = {
   min_approvals: number
   users: Array<string> | undefined | null
   teams: Array<string> | undefined | null
 }
+
+export type BasicRule = BaseRule & RuleCriteria
+
+export type OrRule = BaseRule & {
+  any: RuleCriteria[]
+}
+
+export type AndRule = BaseRule & {
+  all: RuleCriteria[]
+}
+
+export type RuleKind = "BasicRule" | "OrRule" | "AndRule"
+export type Rule = BasicRule | OrRule | AndRule
 
 export type Configuration = {
   rules: Rule[]
 }
 
 export type RuleUserInfo = { team: string | null }
+
+export type MatchedRule = {
+  name: string
+  min_approvals: number
+  users: Map<string, RuleUserInfo>
+  kind: "BasicRule" | "AndRule" | "OrRule"
+  id: number
+}
+
+export class RuleSuccess {
+  constructor(public rule: MatchedRule) {}
+}
+export class RuleFailure {
+  constructor(
+    public rule: MatchedRule,
+    public problem: string,
+    public usersToAskForReview: Map<string, RuleUserInfo>,
+  ) {}
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,29 +51,22 @@ export type AndRule = BaseRule & {
 export type RuleKind = "BasicRule" | "OrRule" | "AndRule"
 export type Rule = BasicRule | OrRule | AndRule
 
-type RuleConfiguration<Kind extends RuleKind> = Kind extends "BasicRule"
-  ? {
-      kind: Kind
-      uniqueFields: ["min_approvals", "teams", "users"]
-      invalidFields: ["any", "all"]
-    }
-  : Kind extends "AndRule"
-  ? {
-      kind: Kind
-      uniqueFields: ["all"]
-      invalidFields: ["min_approvals", "teams", "users", "any"]
-    }
-  : Kind extends "OrRule"
-  ? {
-      kind: Kind
-      uniqueFields: ["any"]
-      invalidFields: ["min_approvals", "teams", "users", "all"]
-    }
-  : never
 export type RulesConfigurations = {
-  basic: RuleConfiguration<"BasicRule">
-  and: RuleConfiguration<"AndRule">
-  or: RuleConfiguration<"OrRule">
+  basic: {
+    kind: "BasicRule"
+    uniqueFields: ["min_approvals", "teams", "users"]
+    invalidFields: ["any", "all"]
+  }
+  and: {
+    kind: "AndRule"
+    uniqueFields: ["all"]
+    invalidFields: ["min_approvals", "teams", "users", "any"]
+  }
+  or: {
+    kind: "OrRule"
+    uniqueFields: ["any"]
+    invalidFields: ["min_approvals", "teams", "users", "all"]
+  }
 }
 
 export type Configuration = {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -2,23 +2,41 @@ import Joi from "joi"
 
 import { Configuration, Rule, RuleCriteria } from "./types"
 
-const ruleCriteria = {
-  min_approvals: Joi.number().optional().min(1).allow(null),
-  users: Joi.array().items(Joi.string()).optional().allow(null),
-  teams: Joi.array().items(Joi.string()).optional().allow(null),
+const ruleCriteria = function ({
+  isMinApprovalsOptional,
+}: {
+  isMinApprovalsOptional: boolean
+}) {
+  let minApprovals = Joi.number().min(1)
+  if (isMinApprovalsOptional) {
+    minApprovals = minApprovals.optional().allow(null)
+  }
+  return {
+    min_approvals: minApprovals,
+    users: Joi.array().items(Joi.string()).optional().allow(null),
+    teams: Joi.array().items(Joi.string()).optional().allow(null),
+  }
 }
 
 const ruleSchema = Joi.object<Rule>().keys({
   name: Joi.string().required(),
   condition: Joi.string().required(),
   check_type: Joi.string().valid("diff", "changed_files").required(),
-  ...ruleCriteria,
+  ...ruleCriteria({ isMinApprovalsOptional: true }),
   all: Joi.array()
-    .items(Joi.object<RuleCriteria>().keys(ruleCriteria))
+    .items(
+      Joi.object<RuleCriteria>().keys(
+        ruleCriteria({ isMinApprovalsOptional: false }),
+      ),
+    )
     .optional()
     .allow(null),
   any: Joi.array()
-    .items(Joi.object<RuleCriteria>().keys(ruleCriteria))
+    .items(
+      Joi.object<RuleCriteria>().keys(
+        ruleCriteria({ isMinApprovalsOptional: false }),
+      ),
+    )
     .optional()
     .allow(null),
 })

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,14 +1,26 @@
 import Joi from "joi"
 
-import { Configuration, Rule } from "./types"
+import { Configuration, Rule, RuleCriteria } from "./types"
+
+const ruleCriteria = {
+  min_approvals: Joi.number().optional().min(1).allow(null),
+  users: Joi.array().items(Joi.string()).optional().allow(null),
+  teams: Joi.array().items(Joi.string()).optional().allow(null),
+}
 
 const ruleSchema = Joi.object<Rule>().keys({
   name: Joi.string().required(),
   condition: Joi.string().required(),
   check_type: Joi.string().valid("diff", "changed_files").required(),
-  min_approvals: Joi.number().required().min(1),
-  users: Joi.array().items(Joi.string()).optional().allow(null),
-  teams: Joi.array().items(Joi.string()).optional().allow(null),
+  ...ruleCriteria,
+  all: Joi.array()
+    .items(Joi.object<RuleCriteria>().keys(ruleCriteria))
+    .optional()
+    .allow(null),
+  any: Joi.array()
+    .items(Joi.object<RuleCriteria>().keys(ruleCriteria))
+    .optional()
+    .allow(null),
 })
 
 export const configurationSchema = Joi.object<Configuration>().keys({

--- a/test/batch/configuration.ts
+++ b/test/batch/configuration.ts
@@ -1,5 +1,6 @@
 import { Octokit } from "@octokit/rest"
 import nock from "nock"
+import YAML from "yaml"
 
 import {
   basePR,
@@ -12,6 +13,7 @@ import {
 } from "test/constants"
 import Logger from "test/logger"
 
+import { rulesConfigurations } from "src/constants"
 import { runChecks } from "src/core"
 
 describe("Configuration", function () {
@@ -95,6 +97,109 @@ describe("Configuration", function () {
       await runChecks(basePR, octokit, logger, {
         configFilePath,
         locksReviewTeam: "",
+      }),
+    ).toBe("failure")
+
+    expect(logHistory).toMatchSnapshot()
+  })
+
+  for (const { kind, invalidFields } of Object.values(rulesConfigurations)) {
+    const goodRule = (function () {
+      switch (kind) {
+        case "BasicRule": {
+          return {
+            name: condition,
+            condition: condition,
+            check_type: "diff",
+            min_approvals: 1,
+          }
+        }
+        case "AndRule": {
+          return {
+            name: condition,
+            condition: condition,
+            check_type: "diff",
+            all: [],
+          }
+        }
+        case "OrRule": {
+          return {
+            name: condition,
+            condition: condition,
+            check_type: "diff",
+            any: [],
+          }
+        }
+        default: {
+          const exhaustivenessCheck: never = kind
+          throw new Error(`Rule kind is not handled: ${exhaustivenessCheck}`)
+        }
+      }
+    })()
+
+    for (const invalidField of invalidFields) {
+      const invalidFieldValidValue = (function () {
+        switch (invalidField) {
+          case "all":
+          case "teams":
+          case "users":
+          case "any": {
+            return []
+          }
+          case "min_approvals": {
+            return 1
+          }
+          default: {
+            const exhaustivenessCheck: never = invalidField
+            throw new Error(
+              `invalidField is not handled: ${exhaustivenessCheck}`,
+            )
+          }
+        }
+      })()
+
+      it(`Rule kind ${kind} does not allow invalid field ${invalidField}`, async function () {
+        const badRule = { ...goodRule, [invalidField]: invalidFieldValidValue }
+
+        nock(githubApi)
+          .get(configFileContentsApiPath)
+          .reply(200, {
+            content: Buffer.from(YAML.stringify({ rules: [badRule] })).toString(
+              "base64",
+            ),
+          })
+
+        expect(
+          await runChecks(basePR, octokit, logger, {
+            configFilePath,
+            locksReviewTeam: team,
+          }),
+        ).toBe("failure")
+
+        expect(logHistory).toMatchSnapshot()
+      })
+    }
+  }
+
+  it("Configuration is invalid if min_approvals is less than 1", async function () {
+    nock(githubApi)
+      .get(configFileContentsApiPath)
+      .reply(200, {
+        content: Buffer.from(
+          `
+          rules:
+            - name: ${condition}
+              condition: ${condition}
+              check_type: diff
+              min_approvals: 0
+          `,
+        ).toString("base64"),
+      })
+
+    expect(
+      await runChecks(basePR, octokit, logger, {
+        configFilePath,
+        locksReviewTeam: team,
       }),
     ).toBe("failure")
 

--- a/test/batch/configuration.ts.snap
+++ b/test/batch/configuration.ts.snap
@@ -57,6 +57,23 @@ Array [
 ]
 `;
 
+exports[`Configuration Configuration is invalid if min_approvals is less than 1 2`] = `
+Array [
+  "ERROR:  Configuration file is invalid",
+  "[Error [ValidationError]: \\"rules[0].min_approvals\\" must be greater than or equal to 1] {
+  _original: { rules: [ [Object] ] },
+  details: [
+    {
+      message: '\\"rules[0].min_approvals\\" must be greater than or equal to 1',
+      path: [Array],
+      type: 'number.min',
+      context: [Object]
+    }
+  ]
+}",
+]
+`;
+
 exports[`Configuration Configuration is invalid if min_approvals is missing 1`] = `
 Array [
   "ERROR:  Configuration file is invalid",
@@ -88,5 +105,65 @@ Array [
     }
   ]
 }",
+]
+`;
+
+exports[`Configuration Rule kind AndRule does not allow invalid field any 1`] = `
+Array [
+  "ERROR:  Rule \\"condition\\" was expected to be of kind \\"AndRule\\" because it had the field \\"all\\", but it also has the field \\"any\\", which belongs to another kind. Mixing fields from different kinds of rules is not allowed.",
+]
+`;
+
+exports[`Configuration Rule kind AndRule does not allow invalid field min_approvals 1`] = `
+Array [
+  "ERROR:  Rule \\"condition\\" was expected to be of kind \\"BasicRule\\" because it had the field \\"min_approvals\\", but it also has the field \\"all\\", which belongs to another kind. Mixing fields from different kinds of rules is not allowed.",
+]
+`;
+
+exports[`Configuration Rule kind AndRule does not allow invalid field teams 1`] = `
+Array [
+  "ERROR:  Rule \\"condition\\" was expected to be of kind \\"BasicRule\\" because it had the field \\"teams\\", but it also has the field \\"all\\", which belongs to another kind. Mixing fields from different kinds of rules is not allowed.",
+]
+`;
+
+exports[`Configuration Rule kind AndRule does not allow invalid field users 1`] = `
+Array [
+  "ERROR:  Rule \\"condition\\" was expected to be of kind \\"BasicRule\\" because it had the field \\"users\\", but it also has the field \\"all\\", which belongs to another kind. Mixing fields from different kinds of rules is not allowed.",
+]
+`;
+
+exports[`Configuration Rule kind BasicRule does not allow invalid field all 1`] = `
+Array [
+  "ERROR:  Rule \\"condition\\" was expected to be of kind \\"BasicRule\\" because it had the field \\"min_approvals\\", but it also has the field \\"all\\", which belongs to another kind. Mixing fields from different kinds of rules is not allowed.",
+]
+`;
+
+exports[`Configuration Rule kind BasicRule does not allow invalid field any 1`] = `
+Array [
+  "ERROR:  Rule \\"condition\\" was expected to be of kind \\"BasicRule\\" because it had the field \\"min_approvals\\", but it also has the field \\"any\\", which belongs to another kind. Mixing fields from different kinds of rules is not allowed.",
+]
+`;
+
+exports[`Configuration Rule kind OrRule does not allow invalid field all 1`] = `
+Array [
+  "ERROR:  Rule \\"condition\\" was expected to be of kind \\"AndRule\\" because it had the field \\"all\\", but it also has the field \\"any\\", which belongs to another kind. Mixing fields from different kinds of rules is not allowed.",
+]
+`;
+
+exports[`Configuration Rule kind OrRule does not allow invalid field min_approvals 1`] = `
+Array [
+  "ERROR:  Rule \\"condition\\" was expected to be of kind \\"BasicRule\\" because it had the field \\"min_approvals\\", but it also has the field \\"any\\", which belongs to another kind. Mixing fields from different kinds of rules is not allowed.",
+]
+`;
+
+exports[`Configuration Rule kind OrRule does not allow invalid field teams 1`] = `
+Array [
+  "ERROR:  Rule \\"condition\\" was expected to be of kind \\"BasicRule\\" because it had the field \\"teams\\", but it also has the field \\"any\\", which belongs to another kind. Mixing fields from different kinds of rules is not allowed.",
+]
+`;
+
+exports[`Configuration Rule kind OrRule does not allow invalid field users 1`] = `
+Array [
+  "ERROR:  Rule \\"condition\\" was expected to be of kind \\"BasicRule\\" because it had the field \\"users\\", but it also has the field \\"any\\", which belongs to another kind. Mixing fields from different kinds of rules is not allowed.",
 ]
 `;

--- a/test/batch/configuration.ts.snap
+++ b/test/batch/configuration.ts.snap
@@ -57,23 +57,6 @@ Array [
 ]
 `;
 
-exports[`Configuration Configuration is invalid if min_approvals is less than 1 2`] = `
-Array [
-  "ERROR:  Configuration file is invalid",
-  "[Error [ValidationError]: \\"rules[0].min_approvals\\" must be greater than or equal to 1] {
-  _original: { rules: [ [Object] ] },
-  details: [
-    {
-      message: '\\"rules[0].min_approvals\\" must be greater than or equal to 1',
-      path: [Array],
-      type: 'number.min',
-      context: [Object]
-    }
-  ]
-}",
-]
-`;
-
 exports[`Configuration Configuration is invalid if min_approvals is missing 1`] = `
 Array [
   "ERROR:  Configuration file is invalid",
@@ -165,5 +148,103 @@ Array [
 exports[`Configuration Rule kind OrRule does not allow invalid field users 1`] = `
 Array [
   "ERROR:  Rule \\"condition\\" was expected to be of kind \\"BasicRule\\" because it had the field \\"users\\", but it also has the field \\"any\\", which belongs to another kind. Mixing fields from different kinds of rules is not allowed.",
+]
+`;
+
+exports[`Configuration min_approvals is invalid for AndRule if it is less than 1 1`] = `
+Array [
+  "ERROR:  Configuration file is invalid",
+  "[Error [ValidationError]: \\"rules[0].all[0].min_approvals\\" must be greater than or equal to 1] {
+  _original: { rules: [ [Object] ] },
+  details: [
+    {
+      message: '\\"rules[0].all[0].min_approvals\\" must be greater than or equal to 1',
+      path: [Array],
+      type: 'number.min',
+      context: [Object]
+    }
+  ]
+}",
+]
+`;
+
+exports[`Configuration min_approvals is invalid for AndRule if it is null 1`] = `
+Array [
+  "ERROR:  Configuration file is invalid",
+  "[Error [ValidationError]: \\"rules[0].all[0].min_approvals\\" must be a number] {
+  _original: { rules: [ [Object] ] },
+  details: [
+    {
+      message: '\\"rules[0].all[0].min_approvals\\" must be a number',
+      path: [Array],
+      type: 'number.base',
+      context: [Object]
+    }
+  ]
+}",
+]
+`;
+
+exports[`Configuration min_approvals is invalid for BasicRule if it is less than 1 1`] = `
+Array [
+  "ERROR:  Configuration file is invalid",
+  "[Error [ValidationError]: \\"rules[0].min_approvals\\" must be greater than or equal to 1] {
+  _original: { rules: [ [Object] ] },
+  details: [
+    {
+      message: '\\"rules[0].min_approvals\\" must be greater than or equal to 1',
+      path: [Array],
+      type: 'number.min',
+      context: [Object]
+    }
+  ]
+}",
+]
+`;
+
+exports[`Configuration min_approvals is invalid for BasicRule if it is null 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "ERROR:  Rule \\"condition\\" has invalid min_approvals",
+  "{
+  name: 'condition',
+  condition: 'condition',
+  check_type: 'diff',
+  min_approvals: null
+}",
+]
+`;
+
+exports[`Configuration min_approvals is invalid for OrRule if it is less than 1 1`] = `
+Array [
+  "ERROR:  Configuration file is invalid",
+  "[Error [ValidationError]: \\"rules[0].any[0].min_approvals\\" must be greater than or equal to 1] {
+  _original: { rules: [ [Object] ] },
+  details: [
+    {
+      message: '\\"rules[0].any[0].min_approvals\\" must be greater than or equal to 1',
+      path: [Array],
+      type: 'number.min',
+      context: [Object]
+    }
+  ]
+}",
+]
+`;
+
+exports[`Configuration min_approvals is invalid for OrRule if it is null 1`] = `
+Array [
+  "ERROR:  Configuration file is invalid",
+  "[Error [ValidationError]: \\"rules[0].any[0].min_approvals\\" must be a number] {
+  _original: { rules: [ [Object] ] },
+  details: [
+    {
+      message: '\\"rules[0].any[0].min_approvals\\" must be a number',
+      path: [Array],
+      type: 'number.base',
+      context: [Object]
+    }
+  ]
+}",
 ]
 `;

--- a/test/batch/rules.ts.snap
+++ b/test/batch/rules.ts.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Rules Approved as an AndRule specifying only users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true }
+}",
+]
+`;
+
+exports[`Rules Approved as an AndRule specifying only users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true }
+}",
+]
+`;
+
+exports[`Rules Approved as an OrRule specifying only users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true }
+}",
+]
+`;
+
+exports[`Rules Approved as an OrRule specifying only users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true }
+}",
+]
+`;
+
 exports[`Rules Approved on rule including both teams and users for changed_files 1`] = `
 Array [
   "Changed files Set(1) { 'condition' }",
@@ -125,6 +167,68 @@ Array [
   { id: 0, user: 'userCoworker', isApproval: true },
   { id: 1, user: 'userCoworker2', isApproval: true }
 }",
+]
+`;
+
+exports[`Rules Has no approval as an AndRule specifying only users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(2) {
+  'userCoworker' => { team: null },
+  'userCoworker2' => { team: null }
+}",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "",
+]
+`;
+
+exports[`Rules Has no approval as an AndRule specifying only users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(2) {
+  'userCoworker' => { team: null },
+  'userCoworker2' => { team: null }
+}",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "",
+]
+`;
+
+exports[`Rules Has no approval as an OrRule specifying only users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(2) {
+  'userCoworker' => { team: null },
+  'userCoworker2' => { team: null }
+}",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "",
+]
+`;
+
+exports[`Rules Has no approval as an OrRule specifying only users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(2) {
+  'userCoworker' => { team: null },
+  'userCoworker2' => { team: null }
+}",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "",
 ]
 `;
 
@@ -293,6 +397,44 @@ Array [
   "ERROR:  The following problems were found:",
   "Rule \\"LOCKS TOUCHED\\" needs at least 2 approvals, but 0 were matched. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team).",
   "",
+]
+`;
+
+exports[`Rules Is missing approval as an AndRule specifying only users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
+  "usersToAskForReview Map(1) { 'userCoworker2' => { team: null } }",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "",
+]
+`;
+
+exports[`Rules Is missing approval as an AndRule specifying only users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
+  "usersToAskForReview Map(1) { 'userCoworker2' => { team: null } }",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "",
+]
+`;
+
+exports[`Rules Is missing approval as an OrRule specifying only users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
+]
+`;
+
+exports[`Rules Is missing approval as an OrRule specifying only users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
 ]
 `;
 

--- a/test/batch/rules.ts.snap
+++ b/test/batch/rules.ts.snap
@@ -1,47 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Rules Approved as an AndRule specifying only users for changed_files 1`] = `
-Array [
-  "Changed files Set(1) { 'condition' }",
-  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
-  "latestReviews [Map Iterator] {
-  { id: 0, user: 'userCoworker', isApproval: true },
-  { id: 1, user: 'userCoworker2', isApproval: true }
-}",
-]
-`;
-
-exports[`Rules Approved as an AndRule specifying only users for diff 1`] = `
-Array [
-  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
-  "latestReviews [Map Iterator] {
-  { id: 0, user: 'userCoworker', isApproval: true },
-  { id: 1, user: 'userCoworker2', isApproval: true }
-}",
-]
-`;
-
-exports[`Rules Approved as an OrRule specifying only users for changed_files 1`] = `
-Array [
-  "Changed files Set(1) { 'condition' }",
-  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
-  "latestReviews [Map Iterator] {
-  { id: 0, user: 'userCoworker', isApproval: true },
-  { id: 1, user: 'userCoworker2', isApproval: true }
-}",
-]
-`;
-
-exports[`Rules Approved as an OrRule specifying only users for diff 1`] = `
-Array [
-  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
-  "latestReviews [Map Iterator] {
-  { id: 0, user: 'userCoworker', isApproval: true },
-  { id: 1, user: 'userCoworker2', isApproval: true }
-}",
-]
-`;
-
 exports[`Rules Approved on rule including both teams and users for changed_files 1`] = `
 Array [
   "Changed files Set(1) { 'condition' }",
@@ -167,68 +125,6 @@ Array [
   { id: 0, user: 'userCoworker', isApproval: true },
   { id: 1, user: 'userCoworker2', isApproval: true }
 }",
-]
-`;
-
-exports[`Rules Has no approval as an AndRule specifying only users for changed_files 1`] = `
-Array [
-  "Changed files Set(1) { 'condition' }",
-  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
-  "latestReviews [Map Iterator] {  }",
-  "usersToAskForReview Map(2) {
-  'userCoworker' => { team: null },
-  'userCoworker2' => { team: null }
-}",
-  "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
-  "",
-]
-`;
-
-exports[`Rules Has no approval as an AndRule specifying only users for diff 1`] = `
-Array [
-  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
-  "latestReviews [Map Iterator] {  }",
-  "usersToAskForReview Map(2) {
-  'userCoworker' => { team: null },
-  'userCoworker2' => { team: null }
-}",
-  "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
-  "",
-]
-`;
-
-exports[`Rules Has no approval as an OrRule specifying only users for changed_files 1`] = `
-Array [
-  "Changed files Set(1) { 'condition' }",
-  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
-  "latestReviews [Map Iterator] {  }",
-  "usersToAskForReview Map(2) {
-  'userCoworker' => { team: null },
-  'userCoworker2' => { team: null }
-}",
-  "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
-  "",
-]
-`;
-
-exports[`Rules Has no approval as an OrRule specifying only users for diff 1`] = `
-Array [
-  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
-  "latestReviews [Map Iterator] {  }",
-  "usersToAskForReview Map(2) {
-  'userCoworker' => { team: null },
-  'userCoworker2' => { team: null }
-}",
-  "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
-  "",
 ]
 `;
 
@@ -400,44 +296,6 @@ Array [
 ]
 `;
 
-exports[`Rules Is missing approval as an AndRule specifying only users for changed_files 1`] = `
-Array [
-  "Changed files Set(1) { 'condition' }",
-  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
-  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
-  "usersToAskForReview Map(1) { 'userCoworker2' => { team: null } }",
-  "ERROR:  The following problems were found:",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
-  "",
-]
-`;
-
-exports[`Rules Is missing approval as an AndRule specifying only users for diff 1`] = `
-Array [
-  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
-  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
-  "usersToAskForReview Map(1) { 'userCoworker2' => { team: null } }",
-  "ERROR:  The following problems were found:",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
-  "",
-]
-`;
-
-exports[`Rules Is missing approval as an OrRule specifying only users for changed_files 1`] = `
-Array [
-  "Changed files Set(1) { 'condition' }",
-  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
-  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
-]
-`;
-
-exports[`Rules Is missing approval as an OrRule specifying only users for diff 1`] = `
-Array [
-  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
-  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
-]
-`;
-
 exports[`Rules Is missing approval on rule including both teams and users for changed_files 1`] = `
 Array [
   "Changed files Set(1) { 'condition' }",
@@ -579,5 +437,435 @@ Array [
   "ERROR:  The following problems were found:",
   "Rule \\"LOCKS TOUCHED\\" needs at least 2 approvals, but 1 were matched. The following users have not approved yet: userCoworker2 (team: team).",
   "",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Approved specifying both teams and users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true },
+  { id: 2, user: 'userCoworker3', isApproval: true }
+}",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Approved specifying both teams and users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true },
+  { id: 2, user: 'userCoworker3', isApproval: true }
+}",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Approved specifying only teams for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true }
+}",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Approved specifying only teams for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true }
+}",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Approved specifying only users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true }
+}",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Approved specifying only users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true }
+}",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Has no approval specifying both teams and users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(2) {
+  'userCoworker2' => { team: 'team1' },
+  'userCoworker3' => { team: null }
+}",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team1).",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"condition[2]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker3.",
+  "",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Has no approval specifying both teams and users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(2) {
+  'userCoworker2' => { team: 'team1' },
+  'userCoworker3' => { team: null }
+}",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team1).",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"condition[2]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker3.",
+  "",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Has no approval specifying only teams for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(1) { 'userCoworker2' => { team: 'team1' } }",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team1).",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Has no approval specifying only teams for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(1) { 'userCoworker2' => { team: 'team1' } }",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team1).",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Has no approval specifying only users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(2) {
+  'userCoworker' => { team: null },
+  'userCoworker2' => { team: null }
+}",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Has no approval specifying only users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(2) {
+  'userCoworker' => { team: null },
+  'userCoworker2' => { team: null }
+}",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Is missing approval specifying both teams and users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
+  "usersToAskForReview Map(2) {
+  'userCoworker2' => { team: 'team2' },
+  'userCoworker3' => { team: null }
+}",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"condition[2]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker3.",
+  "",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Is missing approval specifying both teams and users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
+  "usersToAskForReview Map(2) {
+  'userCoworker2' => { team: 'team2' },
+  'userCoworker3' => { team: null }
+}",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"condition[2]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker3.",
+  "",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Is missing approval specifying only teams for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
+  "usersToAskForReview Map(1) { 'userCoworker2' => { team: 'team2' } }",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Is missing approval specifying only teams for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
+  "usersToAskForReview Map(1) { 'userCoworker2' => { team: 'team2' } }",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Is missing approval specifying only users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
+  "usersToAskForReview Map(1) { 'userCoworker2' => { team: null } }",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "",
+]
+`;
+
+exports[`Rules Rule kind AndRule: Is missing approval specifying only users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
+  "usersToAskForReview Map(1) { 'userCoworker2' => { team: null } }",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Approved specifying both teams and users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true },
+  { id: 2, user: 'userCoworker3', isApproval: true }
+}",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Approved specifying both teams and users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true },
+  { id: 2, user: 'userCoworker3', isApproval: true }
+}",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Approved specifying only teams for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true }
+}",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Approved specifying only teams for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true }
+}",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Approved specifying only users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true }
+}",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Approved specifying only users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {
+  { id: 0, user: 'userCoworker', isApproval: true },
+  { id: 1, user: 'userCoworker2', isApproval: true }
+}",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Has no approval specifying both teams and users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(2) {
+  'userCoworker2' => { team: 'team1' },
+  'userCoworker3' => { team: null }
+}",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team1).",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"condition[2]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker3.",
+  "",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Has no approval specifying both teams and users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(2) {
+  'userCoworker2' => { team: 'team1' },
+  'userCoworker3' => { team: null }
+}",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team1).",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"condition[2]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker3.",
+  "",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Has no approval specifying only teams for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(1) { 'userCoworker2' => { team: 'team1' } }",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team1).",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Has no approval specifying only teams for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(1) { 'userCoworker2' => { team: 'team1' } }",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team1).",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Has no approval specifying only users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(2) {
+  'userCoworker' => { team: null },
+  'userCoworker2' => { team: null }
+}",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Has no approval specifying only users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] {  }",
+  "usersToAskForReview Map(2) {
+  'userCoworker' => { team: null },
+  'userCoworker2' => { team: null }
+}",
+  "ERROR:  The following problems were found:",
+  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
+  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Is missing approval specifying both teams and users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Is missing approval specifying both teams and users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Is missing approval specifying only teams for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Is missing approval specifying only teams for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Is missing approval specifying only users for changed_files 1`] = `
+Array [
+  "Changed files Set(1) { 'condition' }",
+  "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
+]
+`;
+
+exports[`Rules Rule kind OrRule: Is missing approval specifying only users for diff 1`] = `
+Array [
+  "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
+  "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
 ]
 `;

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,4 +1,4 @@
-import { PR } from "src/types"
+import { AndRule, BasicRule, OrRule, PR } from "src/types"
 
 export const org = "org"
 export const repo = "repo"
@@ -31,4 +31,29 @@ export const basePR: PR = {
   user: { login: user },
   html_url: `${githubWebsite}${org}/${repo}/pull/${prNumber}`,
   diff_url: `${githubWebsite}/${org}/${repo}/pull/${prNumber}.diff`,
+}
+
+export const rulesExamples: {
+  BasicRule: BasicRule
+  AndRule: AndRule
+  OrRule: OrRule
+} = {
+  BasicRule: {
+    name: condition,
+    condition: condition,
+    check_type: "diff",
+    min_approvals: 1,
+  },
+  AndRule: {
+    name: condition,
+    condition: condition,
+    check_type: "diff",
+    all: [],
+  },
+  OrRule: {
+    name: condition,
+    condition: condition,
+    check_type: "diff",
+    any: [],
+  },
 }


### PR DESCRIPTION
:exclamation: on top of #31 

closes #37 

unblocks #32

"And Rule" demo: https://github.com/tripleightech/pr-custom-review-test/runs/4852533321?check_suite_focus=true#step:2:21

"Or Rule" demo: https://github.com/tripleightech/pr-custom-review-test/runs/4852559803?check_suite_focus=true#step:2:16

Test coverage remains high with only the error paths not being touched for the most part

```
> npm run test -- --coverage

> typescript-action@0.0.0 test
> jest "--coverage"

 PASS  test/batch/configuration.ts
 PASS  test/batch/rules.ts
---------------|---------|----------|---------|---------|----------------------------------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                            
---------------|---------|----------|---------|---------|----------------------------------------------
All files      |   85.23 |       80 |     100 |   85.02 |                                              
 core.ts       |   84.95 |       80 |     100 |   84.72 | ...5,264-266,270,295-296,310-314,324,444-446 
 validation.ts |     100 |      100 |     100 |     100 |                                              
---------------|---------|----------|---------|---------|----------------------------------------------

Test Suites: 2 passed, 2 total
Tests:       89 passed, 89 total
Snapshots:   89 passed, 89 total
Time:        5.019 s
Ran all test suites.
```