### PR TITLE
Include team leads to built-in check

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,17 @@ Three kinds of rules are available:
 - Basic Rule, through which you specify **top-level** `users` and `teams` for
   reaching `min_approvals`
 
-- AND Rule, through which you specify subcondition of `users` and `teams`, each
+- AND Rule, through which you specify subconditions of `users` and `teams`, each
   with its own `min_approvals`, and **all** of them (logical `AND`) should
   reach their respective `min_approvals`
 
-- OR Rule, through which you specify subcondition of `users` and `teams`, each
+- OR Rule, through which you specify subconditions of `users` and `teams`, each
   with its own `min_approvals`, and **any** of them (logical `OR`) should reach
   their respective `min_approvals`
 
 It's not possible to mix fields from different rules kinds. For instance, it's
 invalid to specify a **top-level** `min_approvals` for AND or OR rules: the
-criteria should be put in the subcondition instead.
+criteria should be put in the subconditions instead.
 
 #### Basic Rule syntax <a name="basic-rule-syntax"></a>
 
@@ -165,6 +165,9 @@ jobs:
 
           # The team which will handle the "locks touched" built-in rule.
           locks-review-team: my-custom-team
+
+          # The second team which will handle the "locks touched" built-in rule.
+          team-leads-team: my-custom-leads-team
 
           # Optional: Disable the configuration file and only use built-in checks
           # config-file:

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
   locks-review-team:
     required: true
     description: 'The team which will be asked for review if locks are touched'
+  team-leads-team:
+    required: true
+    description: 'The team leads which will be asked for review if locks are touched'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,3 +20,8 @@ export const rulesConfigurations: RulesConfigurations = {
     invalidFields: ["min_approvals", "teams", "users", "all"],
   },
 }
+
+export const variableNameToActionInputName = {
+  teamLeadsTeam: "team-leads-team",
+  locksReviewTeam: "locks-review-team",
+}

--- a/src/core.ts
+++ b/src/core.ts
@@ -86,7 +86,7 @@ export const runChecks = async function (
   }
   if (teamLeadsTeam.length === 0) {
     logger.failure(
-      `Locks Review Team (action input: ${variableNameToActionInputName.teamLeadsTeam}) should be provided`,
+      `Team Leads Team (action input: ${variableNameToActionInputName.teamLeadsTeam}) should be provided`,
     )
     return commitStateFailure
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -4,6 +4,7 @@ import {
   commitStateFailure,
   commitStateSuccess,
   rulesConfigurations,
+  variableNameToActionInputName,
 } from "./constants"
 import { LoggerInterface } from "./logger"
 import {
@@ -78,11 +79,15 @@ export const runChecks = async function (
   },
 ) {
   if (locksReviewTeam.length === 0) {
-    logger.failure("Locks Review Team should be provided")
+    logger.failure(
+      `Locks Review Team (action input: ${variableNameToActionInputName.locksReviewTeam}) should be provided`,
+    )
     return commitStateFailure
   }
   if (teamLeadsTeam.length === 0) {
-    logger.failure("Team Leads Team should be provided")
+    logger.failure(
+      `Locks Review Team (action input: ${variableNameToActionInputName.teamLeadsTeam}) should be provided`,
+    )
     return commitStateFailure
   }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,13 +2,14 @@ import os from "os"
 import { inspect } from "util"
 
 // GitHub by default logs N lines when the job is starting.
-// N = 5 for pr-custom-review:
+// N = 6 for pr-custom-review:
 // 1. Run org/pr-custom-review@tag
 // 2.   with:
 // 3.     token: ***
 // 4.     config-file: ./.github/pr-custom-review-config.yml
 // 5.     locks-review-team: foo
-const githubLogsInitialLineCount = 5
+// 6.     team-leads-team: foo
+const githubLogsInitialLineCount = 6
 
 export interface LoggerInterface {
   doLog: (...args: any[]) => void

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,6 +106,7 @@ const main = function () {
   runChecks(pr, octokit, logger, {
     configFilePath: getInput("config-file"),
     locksReviewTeam: getInput("locks-review-team"),
+    teamLeadsTeam: getInput("team-leads-team"),
   })
     .then(function (state) {
       finish(state)

--- a/test/batch/configuration.ts
+++ b/test/batch/configuration.ts
@@ -11,6 +11,7 @@ import {
   githubWebsite,
   rulesExamples,
   team,
+  team2,
 } from "test/constants"
 import Logger from "test/logger"
 
@@ -61,6 +62,7 @@ describe("Configuration", function () {
         await runChecks(basePR, octokit, logger, {
           configFilePath,
           locksReviewTeam: team,
+          teamLeadsTeam: team2,
         }),
       ).toBe("failure")
 
@@ -87,6 +89,19 @@ describe("Configuration", function () {
       await runChecks(basePR, octokit, logger, {
         configFilePath,
         locksReviewTeam: team,
+        teamLeadsTeam: team2,
+      }),
+    ).toBe("failure")
+
+    expect(logHistory).toMatchSnapshot()
+  })
+
+  it("Configuration is invalid if teamLeadsTeam is empty or missing", async function () {
+    expect(
+      await runChecks(basePR, octokit, logger, {
+        configFilePath,
+        locksReviewTeam: team,
+        teamLeadsTeam: "",
       }),
     ).toBe("failure")
 
@@ -98,6 +113,7 @@ describe("Configuration", function () {
       await runChecks(basePR, octokit, logger, {
         configFilePath,
         locksReviewTeam: "",
+        teamLeadsTeam: team,
       }),
     ).toBe("failure")
 
@@ -143,6 +159,7 @@ describe("Configuration", function () {
           await runChecks(basePR, octokit, logger, {
             configFilePath,
             locksReviewTeam: team,
+            teamLeadsTeam: team2,
           }),
         ).toBe("failure")
 
@@ -182,6 +199,7 @@ describe("Configuration", function () {
           await runChecks(basePR, octokit, logger, {
             configFilePath,
             locksReviewTeam: team,
+            teamLeadsTeam: team2,
           }),
         ).toBe("failure")
 

--- a/test/batch/configuration.ts
+++ b/test/batch/configuration.ts
@@ -15,7 +15,10 @@ import {
 } from "test/constants"
 import Logger from "test/logger"
 
-import { rulesConfigurations } from "src/constants"
+import {
+  rulesConfigurations,
+  variableNameToActionInputName,
+} from "src/constants"
 import { runChecks } from "src/core"
 
 describe("Configuration", function () {
@@ -96,29 +99,20 @@ describe("Configuration", function () {
     expect(logHistory).toMatchSnapshot()
   })
 
-  it("Configuration is invalid if teamLeadsTeam is empty or missing", async function () {
-    expect(
-      await runChecks(basePR, octokit, logger, {
-        configFilePath,
-        locksReviewTeam: team,
-        teamLeadsTeam: "",
-      }),
-    ).toBe("failure")
+  for (const name in variableNameToActionInputName) {
+    it(`Configuration is invalid if ${name} is empty or missing`, async function () {
+      expect(
+        await runChecks(basePR, octokit, logger, {
+          configFilePath,
+          locksReviewTeam: team,
+          teamLeadsTeam: team2,
+          [name]: "",
+        }),
+      ).toBe("failure")
 
-    expect(logHistory).toMatchSnapshot()
-  })
-
-  it("Configuration is invalid if locksReviewTeam is empty or missing", async function () {
-    expect(
-      await runChecks(basePR, octokit, logger, {
-        configFilePath,
-        locksReviewTeam: "",
-        teamLeadsTeam: team,
-      }),
-    ).toBe("failure")
-
-    expect(logHistory).toMatchSnapshot()
-  })
+      expect(logHistory).toMatchSnapshot()
+    })
+  }
 
   for (const { kind, invalidFields } of Object.values(rulesConfigurations)) {
     const goodRule = rulesExamples[kind]

--- a/test/batch/configuration.ts.snap
+++ b/test/batch/configuration.ts.snap
@@ -36,7 +36,7 @@ Array [
 
 exports[`Configuration Configuration is invalid if locksReviewTeam is empty or missing 1`] = `
 Array [
-  "ERROR:  Locks Review Team should be provided",
+  "ERROR:  Locks Review Team (action input: locks-review-team) should be provided",
 ]
 `;
 
@@ -93,7 +93,7 @@ Array [
 
 exports[`Configuration Configuration is invalid if teamLeadsTeam is empty or missing 1`] = `
 Array [
-  "ERROR:  Team Leads Team should be provided",
+  "ERROR:  Locks Review Team (action input: team-leads-team) should be provided",
 ]
 `;
 

--- a/test/batch/configuration.ts.snap
+++ b/test/batch/configuration.ts.snap
@@ -91,6 +91,12 @@ Array [
 ]
 `;
 
+exports[`Configuration Configuration is invalid if teamLeadsTeam is empty or missing 1`] = `
+Array [
+  "ERROR:  Team Leads Team should be provided",
+]
+`;
+
 exports[`Configuration Rule kind AndRule does not allow invalid field any 1`] = `
 Array [
   "ERROR:  Rule \\"condition\\" was expected to be of kind \\"AndRule\\" because it had the field \\"all\\", but it also has the field \\"any\\", which belongs to another kind. Mixing fields from different kinds of rules is not allowed.",

--- a/test/batch/rules.ts
+++ b/test/batch/rules.ts
@@ -14,7 +14,7 @@ import {
   requestedReviewersApiPath,
   reviewsApiPath,
   team,
-  teamApiPath,
+  team2,
   userCoworker3,
 } from "test/constants"
 import Logger from "test/logger"
@@ -145,6 +145,7 @@ describe("Rules", function () {
           await runChecks(basePR, octokit, logger, {
             configFilePath,
             locksReviewTeam: team,
+            teamLeadsTeam: team2,
           }),
         ).toBe(scenario === "Approved" ? "success" : "failure")
 
@@ -186,6 +187,7 @@ describe("Rules", function () {
           await runChecks(basePR, octokit, logger, {
             configFilePath,
             locksReviewTeam: team,
+            teamLeadsTeam: team2,
           }),
         ).toBe(scenario === "Approved" ? "success" : "failure")
 
@@ -243,6 +245,7 @@ describe("Rules", function () {
           await runChecks(basePR, octokit, logger, {
             configFilePath,
             locksReviewTeam: team,
+            teamLeadsTeam: team2,
           }),
         ).toBe(scenario === "Approved" ? "success" : "failure")
 
@@ -286,6 +289,7 @@ describe("Rules", function () {
           await runChecks(basePR, octokit, logger, {
             configFilePath,
             locksReviewTeam: team,
+            teamLeadsTeam: team2,
           }),
         ).toBe(scenario === "Approved" ? "success" : "failure")
 
@@ -363,6 +367,7 @@ describe("Rules", function () {
             await runChecks(basePR, octokit, logger, {
               configFilePath,
               locksReviewTeam: team,
+              teamLeadsTeam: team2,
             }),
           ).toBe(expected)
 
@@ -451,6 +456,7 @@ describe("Rules", function () {
             await runChecks(basePR, octokit, logger, {
               configFilePath,
               locksReviewTeam: team,
+              teamLeadsTeam: team2,
             }),
           ).toBe(expectedCheckOutcome)
 
@@ -543,6 +549,7 @@ describe("Rules", function () {
             await runChecks(basePR, octokit, logger, {
               configFilePath,
               locksReviewTeam: team,
+              teamLeadsTeam: team2,
             }),
           ).toBe(expectedCheckOutcome)
 
@@ -553,9 +560,13 @@ describe("Rules", function () {
 
     for (const diffSign of ["+", "-"]) {
       it(`${scenario} when lock line is modified (${diffSign})`, async function () {
-        setup({ diff: `${diffSign}🔒 deleting the lock line` })
-
-        nock(githubApi).get(teamApiPath).reply(200, coworkers)
+        setup({
+          diff: `${diffSign}🔒 deleting the lock line`,
+          teams: [
+            { name: team, members: [coworkers[0]] },
+            { name: team2, members: [coworkers[1]] },
+          ],
+        })
 
         switch (scenario) {
           case "Has no approval":
@@ -564,7 +575,8 @@ describe("Rules", function () {
               .post(requestedReviewersApiPath, function (body) {
                 expect(body).toMatchObject({
                   reviewers: [],
-                  team_reviewers: [team],
+                  team_reviewers:
+                    scenario === "Has no approval" ? [team, team2] : [team2],
                 })
                 return true
               })
@@ -577,6 +589,7 @@ describe("Rules", function () {
           await runChecks(basePR, octokit, logger, {
             configFilePath: "",
             locksReviewTeam: team,
+            teamLeadsTeam: team2,
           }),
         ).toBe(scenario === "Approved" ? "success" : "failure")
 
@@ -584,9 +597,13 @@ describe("Rules", function () {
       })
 
       it(`${scenario} when line after lock is modified (${diffSign})`, async function () {
-        setup({ diff: `🔒 lock line\n${diffSign} modified` })
-
-        nock(githubApi).get(teamApiPath).reply(200, coworkers)
+        setup({
+          diff: `🔒 lock line\n${diffSign} modified`,
+          teams: [
+            { name: team, members: [coworkers[0]] },
+            { name: team2, members: [coworkers[1]] },
+          ],
+        })
 
         switch (scenario) {
           case "Has no approval":
@@ -595,7 +612,8 @@ describe("Rules", function () {
               .post(requestedReviewersApiPath, function (body) {
                 expect(body).toMatchObject({
                   reviewers: [],
-                  team_reviewers: [team],
+                  team_reviewers:
+                    scenario === "Has no approval" ? [team, team2] : [team2],
                 })
                 return true
               })
@@ -608,6 +626,7 @@ describe("Rules", function () {
           await runChecks(basePR, octokit, logger, {
             configFilePath: "",
             locksReviewTeam: team,
+            teamLeadsTeam: team2,
           }),
         ).toBe(scenario === "Approved" ? "success" : "failure")
 

--- a/test/batch/rules.ts.snap
+++ b/test/batch/rules.ts.snap
@@ -243,10 +243,11 @@ Array [
   "latestReviews [Map Iterator] {  }",
   "usersToAskForReview Map(2) {
   'userCoworker' => { team: 'team' },
-  'userCoworker2' => { team: 'team' }
+  'userCoworker2' => { team: 'team2' }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"LOCKS TOUCHED\\" needs at least 2 approvals, but 0 were matched. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team).",
+  "Rule \\"LOCKS TOUCHED (team: team)\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker (team: team).",
+  "Rule \\"LOCKS TOUCHED (team: team2)\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -258,10 +259,11 @@ Array [
   "latestReviews [Map Iterator] {  }",
   "usersToAskForReview Map(2) {
   'userCoworker' => { team: 'team' },
-  'userCoworker2' => { team: 'team' }
+  'userCoworker2' => { team: 'team2' }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"LOCKS TOUCHED\\" needs at least 2 approvals, but 0 were matched. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team).",
+  "Rule \\"LOCKS TOUCHED (team: team)\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker (team: team).",
+  "Rule \\"LOCKS TOUCHED (team: team2)\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -273,10 +275,11 @@ Array [
   "latestReviews [Map Iterator] {  }",
   "usersToAskForReview Map(2) {
   'userCoworker' => { team: 'team' },
-  'userCoworker2' => { team: 'team' }
+  'userCoworker2' => { team: 'team2' }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"LOCKS TOUCHED\\" needs at least 2 approvals, but 0 were matched. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team).",
+  "Rule \\"LOCKS TOUCHED (team: team)\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker (team: team).",
+  "Rule \\"LOCKS TOUCHED (team: team2)\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -288,10 +291,11 @@ Array [
   "latestReviews [Map Iterator] {  }",
   "usersToAskForReview Map(2) {
   'userCoworker' => { team: 'team' },
-  'userCoworker2' => { team: 'team' }
+  'userCoworker2' => { team: 'team2' }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"LOCKS TOUCHED\\" needs at least 2 approvals, but 0 were matched. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team).",
+  "Rule \\"LOCKS TOUCHED (team: team)\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker (team: team).",
+  "Rule \\"LOCKS TOUCHED (team: team2)\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -397,9 +401,9 @@ Array [
   "Diff has changes to 🔒 lines or lines following 🔒",
   "No config file provided",
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
-  "usersToAskForReview Map(1) { 'userCoworker2' => { team: 'team' } }",
+  "usersToAskForReview Map(1) { 'userCoworker2' => { team: 'team2' } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"LOCKS TOUCHED\\" needs at least 2 approvals, but 1 were matched. The following users have not approved yet: userCoworker2 (team: team).",
+  "Rule \\"LOCKS TOUCHED (team: team2)\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -409,9 +413,9 @@ Array [
   "Diff has changes to 🔒 lines or lines following 🔒",
   "No config file provided",
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
-  "usersToAskForReview Map(1) { 'userCoworker2' => { team: 'team' } }",
+  "usersToAskForReview Map(1) { 'userCoworker2' => { team: 'team2' } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"LOCKS TOUCHED\\" needs at least 2 approvals, but 1 were matched. The following users have not approved yet: userCoworker2 (team: team).",
+  "Rule \\"LOCKS TOUCHED (team: team2)\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -421,9 +425,9 @@ Array [
   "Diff has changes to 🔒 lines or lines following 🔒",
   "No config file provided",
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
-  "usersToAskForReview Map(1) { 'userCoworker2' => { team: 'team' } }",
+  "usersToAskForReview Map(1) { 'userCoworker2' => { team: 'team2' } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"LOCKS TOUCHED\\" needs at least 2 approvals, but 1 were matched. The following users have not approved yet: userCoworker2 (team: team).",
+  "Rule \\"LOCKS TOUCHED (team: team2)\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -433,9 +437,9 @@ Array [
   "Diff has changes to 🔒 lines or lines following 🔒",
   "No config file provided",
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
-  "usersToAskForReview Map(1) { 'userCoworker2' => { team: 'team' } }",
+  "usersToAskForReview Map(1) { 'userCoworker2' => { team: 'team2' } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"LOCKS TOUCHED\\" needs at least 2 approvals, but 1 were matched. The following users have not approved yet: userCoworker2 (team: team).",
+  "Rule \\"LOCKS TOUCHED (team: team2)\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -5,6 +5,7 @@ export const repo = "repo"
 export const user = "user"
 
 export const team = "team"
+export const team2 = "team2"
 export const userCoworker = "userCoworker"
 export const userCoworker2 = "userCoworker2"
 export const userCoworker3 = "userCoworker3"


### PR DESCRIPTION
:exclamation: on top of #41 

This PR will unblock the missing part of #32 by enabling the following criterion

> any PR which removes or changes [[ a line containing the emoji lock OR a line which immediately follows a line containing only a comment which contains the emoji lock ]] must have approvals from at least one team lead **as well as** either the CTO or the CEO.

Emphasis on the "as well as" (logical `AND`) part which can be modeled easily with "And Rules" from #41.

Demo
  - Team Leads Review Team approved, missing Locks Review Team: https://github.com/tripleightech/pr-custom-review-test/runs/4853176173?check_suite_focus=true#step:2:20
  - Both Team Leads Review Team and Locks Review Team approved: https://github.com/tripleightech/pr-custom-review-test/runs/4853225408?check_suite_focus=true#step:2:14