### PR TITLE
Get all reviews in the PR with octokit.paginate

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const commitStateFailure: CommitState = "failure"
 
 export const maxGithubApiFilesPerPage = 100
 export const maxGithubApiTeamMembersPerPage = 100
+export const maxGithubApiReviewsPerPage = 100
 
 export const rulesConfigurations: RulesConfigurations = {
   basic: {

--- a/src/core.ts
+++ b/src/core.ts
@@ -8,6 +8,7 @@ import {
   commitStateSuccess,
   configFilePath,
   maxGithubApiFilesPerPage,
+  maxGithubApiReviewsPerPage,
   maxGithubApiTeamMembersPerPage,
 } from "./constants"
 import { LoggerInterface } from "./logger"
@@ -407,12 +408,15 @@ export const runChecks = async function (
   }
 
   if (matchedRules.length !== 0) {
-    const reviewsResponse = await octokit.rest.pulls.listReviews({
-      owner: pr.base.repo.owner.login,
-      repo: pr.base.repo.name,
-      pull_number: pr.number,
-    })
-    const { data: reviews } = reviewsResponse
+    const reviews = await octokit.paginate(
+      "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+      {
+        owner: pr.base.repo.owner.login,
+        repo: pr.base.repo.name,
+        pull_number: pr.number,
+        per_page: maxGithubApiReviewsPerPage,
+      },
+    )
 
     const latestReviews: Map<
       number,

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,4 +1,8 @@
-import { configFilePath, maxGithubApiFilesPerPage } from "src/constants"
+import {
+  configFilePath,
+  maxGithubApiFilesPerPage,
+  maxGithubApiReviewsPerPage,
+} from "src/constants"
 import { AndDistinctRule, AndRule, BasicRule, OrRule, PR } from "src/types"
 
 export const org = "org"
@@ -25,7 +29,7 @@ export const condition = "condition"
 export const githubApi = "https://api.github.com"
 export const githubWebsite = "https://github.com"
 export const prApiPath = `/repos/${org}/${repo}/pulls/${prNumber}`
-export const reviewsApiPath = `${prApiPath}/reviews`
+export const reviewsApiPath = `${prApiPath}/reviews?per_page=${maxGithubApiReviewsPerPage}`
 export const changedFilesApiPath = `${prApiPath}/files?per_page=${maxGithubApiFilesPerPage}`
 export const requestedReviewersApiPath = `${prApiPath}/requested_reviewers`
 export const configFileContentsApiPath = `/repos/${org}/${repo}/contents/${encodeURIComponent(


### PR DESCRIPTION
Problem: on PRs with lots of comments such as https://github.com/paritytech/substrate/pull/10951 we might reach an incorrect verdict because not all reviews are listed in a single API page

Solution: get all reviews with `octokit.paginate`