### PR TITLE
Fix intersecting groups for all_distinct

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -472,13 +472,7 @@ export const runChecks = async function (
           const ruleApprovedBy: Set<string> = new Set()
           const subconditionsUsersToAskForReview: Set<string> = new Set()
 
-          toNextSubcondition: for (
-            let i = 0;
-            i < rule.subConditions.length;
-            i++
-          ) {
-            const subCondition = rule.subConditions[i]
-
+          toNextSubcondition: for (const subCondition of rule.subConditions) {
             const pendingUsersToAskForReview: Set<string> = new Set()
 
             for (const user of subCondition.users ?? []) {

--- a/test/batch/rules.ts.snap
+++ b/test/batch/rules.ts.snap
@@ -209,7 +209,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subconditions at index 0 and at index 1 failed. The following users have not approved yet: userCoworker (teams: team, team2), userCoworker2 (team: team2).",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker (teams: team, team2), userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -347,7 +347,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subconditions \\"Locks Reviewers Approvals (team team)\\" and \\"Team Leads Approvals (team team2)\\" failed. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -362,7 +362,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subconditions \\"Locks Reviewers Approvals (team team)\\" and \\"Team Leads Approvals (team team2)\\" failed. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -377,7 +377,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subconditions \\"Locks Reviewers Approvals (team team)\\" and \\"Team Leads Approvals (team team2)\\" failed. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -392,7 +392,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subconditions \\"Locks Reviewers Approvals (team team)\\" and \\"Team Leads Approvals (team team2)\\" failed. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -450,7 +450,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subcondition at index 1 failed. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -573,7 +573,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subcondition \\"Team Leads Approvals (team team2)\\" failed. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -585,7 +585,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subcondition \\"Team Leads Approvals (team team2)\\" failed. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -597,7 +597,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subcondition \\"Team Leads Approvals (team team2)\\" failed. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -609,7 +609,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subcondition \\"Team Leads Approvals (team team2)\\" failed. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -766,7 +766,7 @@ Array [
   'userCoworker2' => { teams: Set(2) { 'team1', 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subconditions at index 0 and at index 1 and at index 2 failed. The following users have not approved yet: userCoworker3, userCoworker2 (teams: team1, team2).",
+  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker3, userCoworker2 (teams: team1, team2).",
   "",
 ]
 `;
@@ -781,7 +781,7 @@ Array [
   'userCoworker2' => { teams: Set(2) { 'team1', 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subconditions at index 0 and at index 1 and at index 2 failed. The following users have not approved yet: userCoworker3, userCoworker2 (teams: team1, team2).",
+  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker3, userCoworker2 (teams: team1, team2).",
   "",
 ]
 `;
@@ -793,7 +793,7 @@ Array [
   "latestReviews [Map Iterator] {  }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(2) { 'team1', 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subconditions at index 0 and at index 1 failed. The following users have not approved yet: userCoworker2 (teams: team1, team2).",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (teams: team1, team2).",
   "",
 ]
 `;
@@ -805,7 +805,7 @@ Array [
   "latestReviews [Map Iterator] {  }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(2) { 'team1', 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subconditions at index 0 and at index 1 failed. The following users have not approved yet: userCoworker2 (teams: team1, team2).",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (teams: team1, team2).",
   "",
 ]
 `;
@@ -820,7 +820,7 @@ Array [
   'userCoworker2' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subconditions at index 0 and at index 1 failed. The following users have not approved yet: userCoworker, userCoworker2.",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker, userCoworker2.",
   "",
 ]
 `;
@@ -835,7 +835,7 @@ Array [
   'userCoworker2' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subconditions at index 0 and at index 1 failed. The following users have not approved yet: userCoworker, userCoworker2.",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker, userCoworker2.",
   "",
 ]
 `;
@@ -850,7 +850,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subconditions at index 1 and at index 2 failed. The following users have not approved yet: userCoworker3, userCoworker2 (team: team2).",
+  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker3, userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -865,7 +865,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subconditions at index 1 and at index 2 failed. The following users have not approved yet: userCoworker3, userCoworker2 (team: team2).",
+  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker3, userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -877,7 +877,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subcondition at index 1 failed. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -889,7 +889,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subcondition at index 1 failed. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -901,7 +901,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: null } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subcondition at index 1 failed. The following users have not approved yet: userCoworker2.",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2.",
   "",
 ]
 `;
@@ -913,7 +913,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: null } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. Subcondition at index 1 failed. The following users have not approved yet: userCoworker2.",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2.",
   "",
 ]
 `;


### PR DESCRIPTION
This PR fixes the situation in https://github.com/paritytech/polkadot/runs/5978667098?check_suite_focus=true#step:2:40

[Given the approvals](https://github.com/paritytech/polkadot/runs/5978667098?check_suite_focus=true#step:2:28):

```
 {
  { id: 937326948, user: 'rphmeier', isApproval: true },
  { id: 937330726, user: 'eskimor', isApproval: true },
  { id: 938487338, user: 'bkchr', isApproval: true }
}
```

The check is failing because `bkchr` counts towards locks-review but then doesn't count towards polkadot-review since it's excluded from the latter.

This PR fixes the scenario by exiting the subconditions once `ruleApprovedBy` reaches `rule.min_approvals` (which is the sum of each individual `min_approvals` throughout all subconditions for `AndDistinctRule`).