### PR TITLE
Improve error message for AndDistinctRule

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -472,13 +472,13 @@ export const runChecks = async function (
           const ruleApprovedBy: Set<string> = new Set()
           const usersPendingApprovals: Set<string> = new Set()
 
-          toNextSubcondition: for (const subCondition of rule.subConditions) {
+          subConditionsLoop: for (const subCondition of rule.subConditions) {
             for (const user of subCondition.users ?? []) {
               if (approvedBy.has(user)) {
                 ruleApprovedBy.add(user)
                 if (ruleApprovedBy.size === rule.min_approvals) {
                   usersPendingApprovals.clear()
-                  break toNextSubcondition
+                  break subConditionsLoop
                 }
               } else {
                 usersPendingApprovals.add(user)
@@ -492,7 +492,7 @@ export const runChecks = async function (
                     ruleApprovedBy.add(user)
                     if (ruleApprovedBy.size === rule.min_approvals) {
                       usersPendingApprovals.clear()
-                      break toNextSubcondition
+                      break subConditionsLoop
                     }
                   } else {
                     usersPendingApprovals.add(user)

--- a/test/batch/rules.ts.snap
+++ b/test/batch/rules.ts.snap
@@ -209,7 +209,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker (teams: team, team2), userCoworker2 (team: team2).",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker (teams: team, team2), userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -347,7 +347,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -362,7 +362,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -377,7 +377,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -392,7 +392,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -450,7 +450,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, but 1 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -573,7 +573,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, but 1 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -585,7 +585,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, but 1 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -597,7 +597,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, but 1 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -609,7 +609,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"Locks touched\\" needs in total 2 DISTINCT approvals, but 1 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -766,7 +766,7 @@ Array [
   'userCoworker2' => { teams: Set(2) { 'team1', 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker3, userCoworker2 (teams: team1, team2).",
+  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker3, userCoworker2 (teams: team1, team2).",
   "",
 ]
 `;
@@ -781,7 +781,7 @@ Array [
   'userCoworker2' => { teams: Set(2) { 'team1', 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker3, userCoworker2 (teams: team1, team2).",
+  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker3, userCoworker2 (teams: team1, team2).",
   "",
 ]
 `;
@@ -793,7 +793,7 @@ Array [
   "latestReviews [Map Iterator] {  }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(2) { 'team1', 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (teams: team1, team2).",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (teams: team1, team2).",
   "",
 ]
 `;
@@ -805,7 +805,7 @@ Array [
   "latestReviews [Map Iterator] {  }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(2) { 'team1', 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (teams: team1, team2).",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (teams: team1, team2).",
   "",
 ]
 `;
@@ -820,7 +820,7 @@ Array [
   'userCoworker2' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker, userCoworker2.",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker, userCoworker2.",
   "",
 ]
 `;
@@ -835,7 +835,7 @@ Array [
   'userCoworker2' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker, userCoworker2.",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker, userCoworker2.",
   "",
 ]
 `;
@@ -850,7 +850,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker3, userCoworker2 (team: team2).",
+  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, but 1 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker3, userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -865,7 +865,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team2' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker3, userCoworker2 (team: team2).",
+  "Rule \\"condition\\" needs in total 3 DISTINCT approvals, but 1 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker3, userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -877,7 +877,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, but 1 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -889,7 +889,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, but 1 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -901,7 +901,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: null } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2.",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, but 1 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2.",
   "",
 ]
 `;
@@ -913,7 +913,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: null } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, meaning users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2.",
+  "Rule \\"condition\\" needs in total 2 DISTINCT approvals, but 1 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition. The following users have not approved yet: userCoworker2.",
   "",
 ]
 `;


### PR DESCRIPTION
Notably it now shows `needs in total X DISTINCT approvals, but Y were given` which makes it easy to know how many approvals are missing