### PR TITLE
Fix starting line count

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,14 +2,10 @@ import os from "os"
 import { inspect } from "util"
 
 // GitHub by default logs N lines when the job is starting.
-// N = 6 for pr-custom-review:
+// N = 2 for pr-custom-review:
 // 1. Run org/pr-custom-review@tag
 // 2.   with:
-// 3.     token: ***
-// 4.     locks-review-team: foo
-// 5.     team-leads-team: foo
-// 6.     action-review-team: foo
-const githubLogsInitialLineCount = 6
+const githubLogsInitialLineCount = 2
 
 export interface LoggerInterface {
   doLog: (...args: any[]) => void


### PR DESCRIPTION
`githubLogsInitialLineCount` became outdated when I moved the tokens from inputs to action configuration in https://github.com/paritytech/pr-custom-review/pull/74. This results in unpleasant UX since because the offset is bigger than it should be GitHub doesn't scroll to the right line, thus forcing users to scroll all the way down to the bottom of the logs manually.