### PR TITLE
Improve approvals review granularity 

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -53,7 +53,7 @@ const processSubconditionMissingApprovers = (
       userToAskForReview = userInfo
     } else if (userInfo.teams === null) {
       userToAskForReview.teams = null
-    } else {
+    } else if (userToAskForReview.teams !== null) {
       userToAskForReview.teams = new Set([
         ...(userToAskForReview.teams ?? []),
         ...(userInfo?.teams ?? []),
@@ -908,7 +908,7 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
           userToAskForReview = userInfo
         } else if (userInfo.teams === null) {
           userToAskForReview.teams = null
-        } else {
+        } else if (userToAskForReview.teams !== null) {
           userToAskForReview.teams = new Set([
             ...(userToAskForReview.teams ?? []),
             ...(userInfo?.teams ?? []),

--- a/src/core.ts
+++ b/src/core.ts
@@ -528,11 +528,8 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
             const approvedBy: Set<string> = new Set()
 
             for (const review of latestReviews.values()) {
-              if (!review.isApproval) {
-                continue
-              }
-
               if (
+                review.isApproval &&
                 rule.subconditions.find(({ usersInfo }) => {
                   return usersInfo.has(review.user)
                 })
@@ -846,11 +843,10 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
               const approvedBy: Set<string> = new Set()
 
               for (const review of latestReviews.values()) {
-                if (!review.isApproval) {
-                  continue
-                }
-
-                if (subcondition.usersInfo.has(review.user)) {
+                if (
+                  review.isApproval &&
+                  subcondition.usersInfo.has(review.user)
+                ) {
                   approvedBy.add(review.user)
                 }
               }

--- a/src/core.ts
+++ b/src/core.ts
@@ -112,10 +112,9 @@ const combineUsers = async (
         continue
       }
 
-      let userInfo = users.get(teamMember)
+      const userInfo = users.get(teamMember)
       if (userInfo === undefined) {
-        userInfo = { teams: new Set([team]) }
-        users.set(teamMember, userInfo)
+        users.set(teamMember, { teams: new Set([team]) })
       } else if (
         /*
           Avoid registering a team for this user if their approval is supposed

--- a/src/core.ts
+++ b/src/core.ts
@@ -579,7 +579,7 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
               /* subcondition Index */ number,
               /* users which approved the subcondition */ Set<string>
             >
-            let bestApproversArrangement: CombinationApprovedBy = new Map()
+            let bestApproversCombination: CombinationApprovedBy = new Map()
 
             for (let i = 0; i < approvalGroups.length; i++) {
               subconditionCombinationsLoop: for (const userStartingCombination of approvalGroups[
@@ -621,8 +621,8 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
                   The least bad combination is the first one tried, since at
                   least it has one approval
                 */
-                if (bestApproversArrangement.size === 0) {
-                  bestApproversArrangement = combinationApprovers
+                if (bestApproversCombination.size === 0) {
+                  bestApproversCombination = combinationApprovers
                 }
 
                 subconditionsLoop: for (
@@ -710,16 +710,16 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
                           Bail out when combination which fulfills all
                           subconditions is found
                         */
-                        bestApproversArrangement = combinationApprovers
+                        bestApproversCombination = combinationApprovers
                         break subconditionCombinationsLoop
                       }
 
                       let approvalCountOfBestCombination = 0
-                      for (const approvers of bestApproversArrangement.values()) {
+                      for (const approvers of bestApproversCombination.values()) {
                         approvalCountOfBestCombination += approvers.size
                       }
                       if (approvalCountNow > approvalCountOfBestCombination) {
-                        bestApproversArrangement = combinationApprovers
+                        bestApproversCombination = combinationApprovers
                       }
 
                       if (
@@ -735,7 +735,7 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
             }
 
             let approvalCountOfBestApproversArrangement = 0
-            for (const approvers of bestApproversArrangement.values()) {
+            for (const approvers of bestApproversCombination.values()) {
               approvalCountOfBestApproversArrangement += approvers.size
             }
             assert(
@@ -750,7 +750,7 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
                 approvalCountOfBestCombination:
                   approvalCountOfBestApproversArrangement,
                 combinationApprovedByMostPeopleOverall: new Map(
-                  Array.from(bestApproversArrangement).map(
+                  Array.from(bestApproversCombination).map(
                     ([subconditionIndex, approvers]) => {
                       return [
                         rule.subconditions[subconditionIndex].name ??
@@ -767,7 +767,7 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
               for (const [
                 subconditionIndex,
                 approvers,
-              ] of bestApproversArrangement) {
+              ] of bestApproversCombination) {
                 const subcondition = rule.subconditions[subconditionIndex]
                 assert(
                   approvers.size === subcondition.min_approvals,
@@ -785,7 +785,7 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
                 approvalGroups.reduce(
                   (acc, { subcondition }, subconditionIndex) => {
                     const approversCount =
-                      bestApproversArrangement.get(subconditionIndex)?.size ?? 0
+                      bestApproversCombination.get(subconditionIndex)?.size ?? 0
 
                     if (approversCount === subcondition.min_approvals) {
                       return acc

--- a/src/core.ts
+++ b/src/core.ts
@@ -53,7 +53,13 @@ const processSubconditionMissingApprovers = (
       userToAskForReview = userInfo
     } else if (userInfo.teams === null) {
       userToAskForReview.teams = null
-    } else if (userToAskForReview.teams !== null) {
+    } else if (
+      /*
+        Avoid registering a team for this user if their approval is supposed
+        to be requested individually
+      */
+      userToAskForReview.teams !== null
+    ) {
       userToAskForReview.teams = new Set([
         ...(userToAskForReview.teams ?? []),
         ...(userInfo?.teams ?? []),
@@ -908,7 +914,13 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
           userToAskForReview = userInfo
         } else if (userInfo.teams === null) {
           userToAskForReview.teams = null
-        } else if (userToAskForReview.teams !== null) {
+        } else if (
+          /*
+            Avoid registering a team for this user if their approval is supposed
+            to be requested individually
+          */
+          userToAskForReview.teams !== null
+        ) {
           userToAskForReview.teams = new Set([
             ...(userToAskForReview.teams ?? []),
             ...(userInfo?.teams ?? []),

--- a/src/core.ts
+++ b/src/core.ts
@@ -118,8 +118,8 @@ const combineUsers = async (
         users.set(teamMember, userInfo)
       } else if (
         /*
-          Avoid registering a team for this user if their approval is
-          supposed to be requested individually
+          Avoid registering a team for this user if their approval is supposed
+          to be requested individually
         */
         userInfo.teams !== null
       ) {
@@ -551,14 +551,17 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
               approval group on each subcondition. This is needed when it would
               be more favorable to use an approval for a different subcondition
               other than the one it could be first matched for that approval.
+
               Consider the following scenario:
                 - Ana has teams: Team2, Team1
                 - Bob has teams: Team2
                 - Ana and Bob have both approved
+
               And suppose that we need 1 distinct approval for Team1 and another
               for Team2. It might be the case that Ana's approval for Team2 is
               registered first, which would make Bob's approval useless for a
               suboptimal outcome.
+
               The most favorable combination to clear the requirement is:
                 - Ana's approval is allocated to Team1
                 - Bob's approval is allocated to Team2
@@ -566,10 +569,11 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
                 - Ana's approval is allocated to Team2
                 - Bob's approval is useless because it can only be allocated to
                   Team1, which was already approved by Ana in this scenario
+
               It is possible to avoid the bad case by brute-forcing every
-              available permutation of approvals' orders and picking the best one
-              found, with bailouts for when the overall target approval count is
-              reached.
+              available permutation of approvals' orders and picking the best
+              one found, with bailouts for when the overall target approval
+              count is reached.
             */
             type CombinationApprovedBy = Map<
               /* subcondition Index */ number,
@@ -582,8 +586,8 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
                 i
               ].subconditionApprovedBy) {
                 /*
-                  The combinations are tried by alternating which user starts the
-                  combination on each pass.
+                  The combinations are tried by alternating which user starts
+                  the combination on each pass.
 
                   Take for instance the following subconditions:
                   - Subcondition 0 approvers: A
@@ -614,8 +618,8 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
                 ])
 
                 /*
-                  The least bad combination is the first one tried, since at least
-                  it has one approval
+                  The least bad combination is the first one tried, since at
+                  least it has one approval
                 */
                 if (bestApproversArrangement.size === 0) {
                   bestApproversArrangement = combinationApprovers
@@ -631,7 +635,8 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
 
                   /*
                     Check if the subcondition's min_approvals target has already
-                    been fulfilled by the initialization of combinationApprovedBy
+                    been fulfilled by the initialization of
+                    combinationApprovedBy
                   */
                   if (j === i) {
                     const approversCount = combinationApprovers.get(j)?.size
@@ -651,8 +656,8 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
 
                   const subconditionApproversPermutator = new Permutator(
                     /*
-                       Permutator mutates the input array, therefore make sure to
-                       *not* pass an array reference to it
+                       Permutator mutates the input array, therefore make sure
+                       to *not* pass an array reference to it
                     */
                     Array.from(subconditionApprovedBy),
                   )
@@ -662,8 +667,8 @@ export const runChecks = async ({ pr, ...ctx }: Context & { pr: PR }) => {
 
                     /*
                       Initialize a new Set here so that the effects of this
-                      permutation doesn't affect combinationApprovers until it is
-                      the right time to commit the results
+                      permutation doesn't affect combinationApprovers until it
+                      is the right time to commit the results
                     */
                     const subconditionApprovers = new Set(
                       combinationApprovers.get(j)?.values(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,6 @@ export type BaseRule = {
 
 export type RuleCriteria = {
   min_approvals: number
-  name?: string
   users?: string[] | null
   teams?: string[] | null
 }
@@ -108,28 +107,17 @@ export type Configuration = {
 
 export type RuleUserInfo = {
   teams: Set<string> | null
-  teamsHistory?: Set<string>
 }
 
-type MatchedRuleBase = {
+export type MatchedRule = {
   name: string
-  users: Map<string, RuleUserInfo>
-  id: number
   kind: RuleKind
-  min_approvals: number
+  subconditions: (Omit<RuleCriteria, "teams" | "users"> & {
+    name: string
+    usersInfo: Map<string, RuleUserInfo>
+  })[]
 }
-export type MatchedRule =
-  | (MatchedRuleBase & {
-      kind: "AndRule" | "OrRule" | "BasicRule"
-    })
-  | (MatchedRuleBase & {
-      kind: "AndDistinctRule"
-      subconditions: RuleCriteria[]
-    })
 
-export class RuleSuccess {
-  constructor(public rule: MatchedRule) {}
-}
 export class RuleFailure {
   constructor(
     public rule: MatchedRule,

--- a/test/batch/rules.ts.snap
+++ b/test/batch/rules.ts.snap
@@ -250,8 +250,8 @@ Array [
 }",
   "ERROR:  The following problems were found:",
   "Rule \\"condition\\" needs in total 2 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition.
-Subcondition \\"condition[0]\\" does not have approval from the following users: userCoworker (teams: team, team2).
-Subcondition \\"condition[1]\\" does not have approval from the following users: userCoworker (teams: team, team2), userCoworker2 (team: team2).",
+Subcondition \\"condition[0]\\" does not have approval from the following users: userCoworker (team: team).
+Subcondition \\"condition[1]\\" does not have approval from the following users: userCoworker (team: team2), userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -266,7 +266,7 @@ Array [
   'userCoworker' => { teams: Set(1) { 'team' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs at least 2 approvals, but 0 were matched. The following users have not approved yet: userCoworker2, userCoworker (team: team).",
+  "Rule \\"condition\\" needs at least 2 approvals, but 0 were given. The following users have not approved yet: userCoworker2, userCoworker (team: team).",
   "",
 ]
 `;
@@ -281,7 +281,7 @@ Array [
   'userCoworker' => { teams: Set(1) { 'team' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs at least 2 approvals, but 0 were matched. The following users have not approved yet: userCoworker2, userCoworker (team: team).",
+  "Rule \\"condition\\" needs at least 2 approvals, but 0 were given. The following users have not approved yet: userCoworker2, userCoworker (team: team).",
   "",
 ]
 `;
@@ -296,7 +296,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs at least 2 approvals, but 0 were matched. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team).",
+  "Rule \\"condition\\" needs at least 2 approvals, but 0 were given. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team).",
   "",
 ]
 `;
@@ -311,7 +311,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs at least 2 approvals, but 0 were matched. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team).",
+  "Rule \\"condition\\" needs at least 2 approvals, but 0 were given. The following users have not approved yet: userCoworker (team: team), userCoworker2 (team: team).",
   "",
 ]
 `;
@@ -326,7 +326,7 @@ Array [
   'userCoworker2' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs at least 2 approvals, but 0 were matched. The following users have not approved yet: userCoworker, userCoworker2.",
+  "Rule \\"condition\\" needs at least 2 approvals, but 0 were given. The following users have not approved yet: userCoworker, userCoworker2.",
   "",
 ]
 `;
@@ -341,7 +341,7 @@ Array [
   'userCoworker2' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs at least 2 approvals, but 0 were matched. The following users have not approved yet: userCoworker, userCoworker2.",
+  "Rule \\"condition\\" needs at least 2 approvals, but 0 were given. The following users have not approved yet: userCoworker, userCoworker2.",
   "",
 ]
 `;
@@ -352,7 +352,7 @@ Array [
   "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
   "latestReviews [Map Iterator] {  }",
   "ERROR:  The following problems were found:",
-  "Rule condition requires at least 2 approvals, but only 0 were given",
+  "Rule \\"condition\\" requires at least 2 approvals, but 0 were given.",
   "",
 ]
 `;
@@ -363,7 +363,7 @@ Array [
   "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
   "latestReviews [Map Iterator] {  }",
   "ERROR:  The following problems were found:",
-  "Rule condition requires at least 2 approvals, but only 0 were given",
+  "Rule \\"condition\\" requires at least 2 approvals, but 0 were given.",
   "",
 ]
 `;
@@ -374,7 +374,7 @@ Array [
   "latestReviews [Map Iterator] {  }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team3' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Action files changed\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team3).",
+  "Rule \\"Action files changed\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team3).",
   "",
 ]
 `;
@@ -477,7 +477,7 @@ Array [
   "Matched expression \\"{\\"include\\":\\"condition\\"}\\" of rule \\"Condition include\\" for the file condition",
   "latestReviews [Map Iterator] {  }",
   "ERROR:  The following problems were found:",
-  "Rule Condition include requires at least 2 approvals, but only 0 were given",
+  "Rule \\"Condition include\\" requires at least 2 approvals, but 0 were given.",
   "",
 ]
 `;
@@ -488,7 +488,7 @@ Array [
   "Matched expression \\"{\\"include\\":\\"condition\\"}\\" of rule \\"Condition include\\" on diff",
   "latestReviews [Map Iterator] {  }",
   "ERROR:  The following problems were found:",
-  "Rule Condition include requires at least 2 approvals, but only 0 were given",
+  "Rule \\"Condition include\\" requires at least 2 approvals, but 0 were given.",
   "",
 ]
 `;
@@ -521,7 +521,7 @@ Array [
   'userCoworker3' => { teams: Set(1) { 'team' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs at least 2 approvals, but 1 were matched. The following users have not approved yet: userCoworker2, userCoworker3 (team: team).",
+  "Rule \\"condition\\" needs at least 2 approvals, but 1 were given. The following users have not approved yet: userCoworker2, userCoworker3 (team: team).",
   "",
 ]
 `;
@@ -536,7 +536,7 @@ Array [
   'userCoworker3' => { teams: Set(1) { 'team' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs at least 2 approvals, but 1 were matched. The following users have not approved yet: userCoworker2, userCoworker3 (team: team).",
+  "Rule \\"condition\\" needs at least 2 approvals, but 1 were given. The following users have not approved yet: userCoworker2, userCoworker3 (team: team).",
   "",
 ]
 `;
@@ -548,7 +548,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs at least 2 approvals, but 1 were matched. The following users have not approved yet: userCoworker2 (team: team).",
+  "Rule \\"condition\\" needs at least 2 approvals, but 1 were given. The following users have not approved yet: userCoworker2 (team: team).",
   "",
 ]
 `;
@@ -560,7 +560,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs at least 2 approvals, but 1 were matched. The following users have not approved yet: userCoworker2 (team: team).",
+  "Rule \\"condition\\" needs at least 2 approvals, but 1 were given. The following users have not approved yet: userCoworker2 (team: team).",
   "",
 ]
 `;
@@ -572,7 +572,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: null } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs at least 2 approvals, but 1 were matched. The following users have not approved yet: userCoworker2.",
+  "Rule \\"condition\\" needs at least 2 approvals, but 1 were given. The following users have not approved yet: userCoworker2.",
   "",
 ]
 `;
@@ -584,7 +584,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: null } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition\\" needs at least 2 approvals, but 1 were matched. The following users have not approved yet: userCoworker2.",
+  "Rule \\"condition\\" needs at least 2 approvals, but 1 were given. The following users have not approved yet: userCoworker2.",
   "",
 ]
 `;
@@ -595,7 +595,7 @@ Array [
   "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "ERROR:  The following problems were found:",
-  "Rule condition requires at least 2 approvals, but only 1 were given",
+  "Rule \\"condition\\" requires at least 2 approvals, but 1 were given.",
   "",
 ]
 `;
@@ -606,7 +606,7 @@ Array [
   "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "ERROR:  The following problems were found:",
-  "Rule condition requires at least 2 approvals, but only 1 were given",
+  "Rule \\"condition\\" requires at least 2 approvals, but 1 were given.",
   "",
 ]
 `;
@@ -617,7 +617,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team3' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Action files changed\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team3).",
+  "Rule \\"Action files changed\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team3).",
   "",
 ]
 `;
@@ -732,7 +732,7 @@ Array [
   "Matched expression \\"{\\"include\\":\\"condition\\"}\\" of rule \\"Condition include\\" for the file condition",
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "ERROR:  The following problems were found:",
-  "Rule Condition include requires at least 2 approvals, but only 1 were given",
+  "Rule \\"Condition include\\" requires at least 2 approvals, but 1 were given.",
   "",
 ]
 `;
@@ -743,7 +743,7 @@ Array [
   "Matched expression \\"{\\"include\\":\\"condition\\"}\\" of rule \\"Condition include\\" on diff",
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "ERROR:  The following problems were found:",
-  "Rule Condition include requires at least 2 approvals, but only 1 were given",
+  "Rule \\"Condition include\\" requires at least 2 approvals, but 1 were given.",
   "",
 ]
 `;
@@ -757,7 +757,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team3' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Action files changed\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker (team: team3), userCoworker2 (team: team3).",
+  "Rule \\"Action files changed\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker (team: team3), userCoworker2 (team: team3).",
   "",
 ]
 `;
@@ -771,7 +771,7 @@ Array [
   'userCoworker2' => { teams: Set(1) { 'team3' } }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"Action files changed\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker (team: team3), userCoworker2 (team: team3).",
+  "Rule \\"Action files changed\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker (team: team3), userCoworker2 (team: team3).",
   "",
 ]
 `;
@@ -900,13 +900,13 @@ Array [
   "Matched expression \\"condition\\" of rule \\"condition\\" for the file condition",
   "latestReviews [Map Iterator] {  }",
   "usersToAskForReview Map(2) {
-  'userCoworker3' => { teams: null },
-  'userCoworker2' => { teams: Set(2) { 'team', 'team2' } }
+  'userCoworker2' => { teams: Set(2) { 'team', 'team2' } },
+  'userCoworker3' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
   "Rule \\"condition\\" needs in total 3 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition.
-Subcondition \\"condition[0]\\" does not have approval from the following users: userCoworker2 (teams: team, team2).
-Subcondition \\"condition[1]\\" does not have approval from the following users: userCoworker2 (teams: team, team2).
+Subcondition \\"condition[0]\\" does not have approval from the following users: userCoworker2 (team: team).
+Subcondition \\"condition[1]\\" does not have approval from the following users: userCoworker2 (team: team2).
 Subcondition \\"condition[2]\\" does not have approval from the following users: userCoworker3.",
   "",
 ]
@@ -918,13 +918,13 @@ Array [
   "Matched expression \\"condition\\" of rule \\"condition\\" on diff",
   "latestReviews [Map Iterator] {  }",
   "usersToAskForReview Map(2) {
-  'userCoworker3' => { teams: null },
-  'userCoworker2' => { teams: Set(2) { 'team', 'team2' } }
+  'userCoworker2' => { teams: Set(2) { 'team', 'team2' } },
+  'userCoworker3' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
   "Rule \\"condition\\" needs in total 3 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition.
-Subcondition \\"condition[0]\\" does not have approval from the following users: userCoworker2 (teams: team, team2).
-Subcondition \\"condition[1]\\" does not have approval from the following users: userCoworker2 (teams: team, team2).
+Subcondition \\"condition[0]\\" does not have approval from the following users: userCoworker2 (team: team).
+Subcondition \\"condition[1]\\" does not have approval from the following users: userCoworker2 (team: team2).
 Subcondition \\"condition[2]\\" does not have approval from the following users: userCoworker3.",
   "",
 ]
@@ -938,8 +938,8 @@ Array [
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(2) { 'team', 'team2' } } }",
   "ERROR:  The following problems were found:",
   "Rule \\"condition\\" needs in total 2 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition.
-Subcondition \\"condition[0]\\" does not have approval from the following users: userCoworker2 (teams: team, team2).
-Subcondition \\"condition[1]\\" does not have approval from the following users: userCoworker2 (teams: team, team2).",
+Subcondition \\"condition[0]\\" does not have approval from the following users: userCoworker2 (team: team).
+Subcondition \\"condition[1]\\" does not have approval from the following users: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -952,8 +952,8 @@ Array [
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(2) { 'team', 'team2' } } }",
   "ERROR:  The following problems were found:",
   "Rule \\"condition\\" needs in total 2 DISTINCT approvals, but 0 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition.
-Subcondition \\"condition[0]\\" does not have approval from the following users: userCoworker2 (teams: team, team2).
-Subcondition \\"condition[1]\\" does not have approval from the following users: userCoworker2 (teams: team, team2).",
+Subcondition \\"condition[0]\\" does not have approval from the following users: userCoworker2 (team: team).
+Subcondition \\"condition[1]\\" does not have approval from the following users: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -1003,8 +1003,8 @@ Array [
   combinationApprovedByMostPeopleOverall: Map(1) { 'condition[0]' => Set(1) { 'userCoworker' } }
 }",
   "usersToAskForReview Map(2) {
-  'userCoworker3' => { teams: null },
-  'userCoworker2' => { teams: Set(1) { 'team2' } }
+  'userCoworker2' => { teams: Set(1) { 'team2' } },
+  'userCoworker3' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
   "Rule \\"condition\\" needs in total 3 DISTINCT approvals, but 1 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition.
@@ -1025,8 +1025,8 @@ Array [
   combinationApprovedByMostPeopleOverall: Map(1) { 'condition[0]' => Set(1) { 'userCoworker' } }
 }",
   "usersToAskForReview Map(2) {
-  'userCoworker3' => { teams: null },
-  'userCoworker2' => { teams: Set(1) { 'team2' } }
+  'userCoworker2' => { teams: Set(1) { 'team2' } },
+  'userCoworker3' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
   "Rule \\"condition\\" needs in total 3 DISTINCT approvals, but 1 were given. Users whose approvals counted towards one criterion are excluded from other criteria. For example: even if a user belongs multiple teams, their approval will only count towards one of them; or even if a user is referenced in multiple subconditions, their approval will only count towards one subcondition.
@@ -1186,9 +1186,9 @@ Array [
   'userCoworker3' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team).",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
-  "Rule \\"condition[2]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker3.",
+  "Subcondition \\"condition[0]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team).
+Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team2).
+Subcondition \\"condition[2]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker3.",
   "",
 ]
 `;
@@ -1203,9 +1203,9 @@ Array [
   'userCoworker3' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team).",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
-  "Rule \\"condition[2]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker3.",
+  "Subcondition \\"condition[0]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team).
+Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team2).
+Subcondition \\"condition[2]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker3.",
   "",
 ]
 `;
@@ -1217,8 +1217,8 @@ Array [
   "latestReviews [Map Iterator] {  }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(2) { 'team', 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team).",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Subcondition \\"condition[0]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team).
+Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -1230,8 +1230,8 @@ Array [
   "latestReviews [Map Iterator] {  }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(2) { 'team', 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team).",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Subcondition \\"condition[0]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team).
+Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -1246,8 +1246,8 @@ Array [
   'userCoworker2' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "Subcondition \\"condition[0]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker.
+Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2.",
   "",
 ]
 `;
@@ -1262,8 +1262,8 @@ Array [
   'userCoworker2' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "Subcondition \\"condition[0]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker.
+Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2.",
   "",
 ]
 `;
@@ -1278,8 +1278,8 @@ Array [
   'userCoworker3' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
-  "Rule \\"condition[2]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker3.",
+  "Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team2).
+Subcondition \\"condition[2]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker3.",
   "",
 ]
 `;
@@ -1294,8 +1294,8 @@ Array [
   'userCoworker3' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
-  "Rule \\"condition[2]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker3.",
+  "Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team2).
+Subcondition \\"condition[2]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker3.",
   "",
 ]
 `;
@@ -1307,7 +1307,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -1319,7 +1319,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(1) { 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -1331,7 +1331,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: null } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2.",
   "",
 ]
 `;
@@ -1343,7 +1343,7 @@ Array [
   "latestReviews [Map Iterator] { { id: 1, user: 'userCoworker', isApproval: true } }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: null } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2.",
   "",
 ]
 `;
@@ -1426,9 +1426,9 @@ Array [
   'userCoworker3' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team).",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
-  "Rule \\"condition[2]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker3.",
+  "Subcondition \\"condition[0]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team).
+Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team2).
+Subcondition \\"condition[2]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker3.",
   "",
 ]
 `;
@@ -1443,9 +1443,9 @@ Array [
   'userCoworker3' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team).",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
-  "Rule \\"condition[2]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker3.",
+  "Subcondition \\"condition[0]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team).
+Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team2).
+Subcondition \\"condition[2]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker3.",
   "",
 ]
 `;
@@ -1457,8 +1457,8 @@ Array [
   "latestReviews [Map Iterator] {  }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(2) { 'team', 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team).",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Subcondition \\"condition[0]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team).
+Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -1470,8 +1470,8 @@ Array [
   "latestReviews [Map Iterator] {  }",
   "usersToAskForReview Map(1) { 'userCoworker2' => { teams: Set(2) { 'team', 'team2' } } }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team).",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2 (team: team2).",
+  "Subcondition \\"condition[0]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team).
+Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2 (team: team2).",
   "",
 ]
 `;
@@ -1486,8 +1486,8 @@ Array [
   'userCoworker2' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "Subcondition \\"condition[0]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker.
+Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2.",
   "",
 ]
 `;
@@ -1502,8 +1502,8 @@ Array [
   'userCoworker2' => { teams: null }
 }",
   "ERROR:  The following problems were found:",
-  "Rule \\"condition[0]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker.",
-  "Rule \\"condition[1]\\" needs at least 1 approvals, but 0 were matched. The following users have not approved yet: userCoworker2.",
+  "Subcondition \\"condition[0]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker.
+Subcondition \\"condition[1]\\" needs at least 1 approvals, but 0 were given. The following users have not approved yet: userCoworker2.",
   "",
 ]
 `;


### PR DESCRIPTION
Review requests currently don't work optimally, as evidenced by https://github.com/paritytech/polkadot/pull/5374#event-6488509108 where the action requested more review from locks-review even though the criterion for that team had already been fulfilled.

This PR attempts to fix that case by having better granularity per-subcondition and improving the way that subconditions are processed internally.

Despite the fairly large internal rework in the core logic, the snapshots changed as expected (and minorly) which is to me a good sign of no regressions being introduced by this PR.