### PR TITLE
Introduce GITHUB_ACCESS_TOKEN_OWNER

### DIFF
--- a/.env.example.cjs
+++ b/.env.example.cjs
@@ -11,6 +11,9 @@ process.env.PORT ??= 3000
 */
 process.env.GITHUB_ACCESS_TOKEN ??= "placeholder"
 
+// API requests are only processed from GITHUB_ACCESS_TOKEN_OWNER
+process.env.GITHUB_ACCESS_TOKEN_OWNER ??= "placeholder"
+
 /*
   NOT REQUIRED
   Set LOG_FORMAT to "json" for JSON logging

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,6 +119,7 @@ build-production:
         --set common.containerPort="$APP_PORT"
         --set common.livenessProbe.httpGet.port="$APP_PORT"
         --set common.readinessProbe.httpGet.port="$APP_PORT"
+        --set common.env.GITHUB_ACCESS_TOKEN_OWNER="$GITHUB_ACCESS_TOKEN_OWNER"
         pr-custom-review helm/
 
 deploy-staging:

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -66,12 +66,20 @@ const main = async () => {
   const serverPort = envNumberVar("PORT")
 
   const githubAccessToken = envVar("GITHUB_ACCESS_TOKEN")
+  const githubAccessTokenOwner = envVar("GITHUB_ACCESS_TOKEN_OWNER")
 
   const octokit = getOctokit(new Octokit(), logger, () => {
     return { authorization: `token ${githubAccessToken}` }
   })
 
-  const ctx: ServerContext = { logger, octokit }
+  const ctx: ServerContext = {
+    logger,
+    octokit,
+    github: {
+      accessToken: githubAccessToken,
+      accessTokenOwner: githubAccessTokenOwner,
+    },
+  }
 
   const server = setup(ctx)
   await server.listen({ host: "0.0.0.0", port: serverPort })

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -7,4 +7,8 @@ import { ServerLogger } from "./logger"
 export type ServerContext = {
   octokit: ExtendedOctokit<Octokit>
   logger: ServerLogger
+  github: {
+    accessToken: string
+    accessTokenOwner: string
+  }
 }


### PR DESCRIPTION
`$GITHUB_ACCESS_TOKEN_OWNER` is useful so that we process only API requests from `$GITHUB_ACCESS_TOKEN_OWNER` (in our case it's paritytech).